### PR TITLE
refactor: 사진 업로드시 반환 URL 변경

### DIFF
--- a/src/main/java/com/market/saessag/domain/photo/service/S3Service.java
+++ b/src/main/java/com/market/saessag/domain/photo/service/S3Service.java
@@ -73,7 +73,7 @@ public class S3Service {
 
             tempFile.delete();
 
-            return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileName);
+            return fileName;
         } catch (S3Exception e) {
             throw new RuntimeException("S3에 파일 업로드 중 문제가 발생했습니다. : " + e.getMessage(), e);
         }


### PR DESCRIPTION
## #️⃣ Issue Number

ex) #40 

## 📝 작업 설명

반환되는 URL에서 https://saessag.s3.ap-northeast-2.amazonaws.com 제외한 나머지 값 반환하도록 수정
위 링크가 포함되도록 반환 했었는데, 프리사인 URL 값을 받기 위해서는 나머지 값만 키로 이용하기 때문에 변경

## 📸스크린샷 (선택)   

## 💬 리뷰 요구사항


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
