### PR TITLE
지도 위치 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3:2.20.0'
 	implementation 'software.amazon.awssdk:core:2.20.0'
 	implementation 'software.amazon.awssdk:auth:2.20.0'
+	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 }
 
 test {

--- a/src/main/java/com/market/saessag/domain/product/controller/ProductController.java
+++ b/src/main/java/com/market/saessag/domain/product/controller/ProductController.java
@@ -2,7 +2,6 @@ package com.market.saessag.domain.product.controller;
 
 import com.market.saessag.domain.product.dto.ProductRequest;
 import com.market.saessag.domain.product.dto.ProductResponse;
-import com.market.saessag.domain.product.entity.Product;
 import com.market.saessag.domain.product.service.ProductService;
 import com.market.saessag.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -62,8 +61,8 @@ public class ProductController {
     //상품 수정
     @PutMapping("/{productId}")
     public ResponseEntity<ApiResponse<ProductResponse>> updateProduct(@PathVariable Long productId,
-                                 @RequestBody Product product) {
-        ProductResponse updatedProduct = productService.updateProduct(productId, product);
+                                 @RequestBody ProductRequest productRequest) {
+        ProductResponse updatedProduct = productService.updateProduct(productId, productRequest);
         ApiResponse<ProductResponse> response = ApiResponse.<ProductResponse>builder()
                 .status("200")
                 .data(updatedProduct)

--- a/src/main/java/com/market/saessag/domain/product/dto/ProductRequest.java
+++ b/src/main/java/com/market/saessag/domain/product/dto/ProductRequest.java
@@ -11,7 +11,10 @@ public class ProductRequest {
     private String title;
     private Long price;
     private String description;
-    private String meetingPlace;
+    private Double latitude;
+    private Double longitude;
+    private String basicAddress;
+    private String detailedAddress;
     private List<String> photo;
     private String status;
 }

--- a/src/main/java/com/market/saessag/domain/product/dto/ProductResponse.java
+++ b/src/main/java/com/market/saessag/domain/product/dto/ProductResponse.java
@@ -14,7 +14,8 @@ public class ProductResponse {
     private String title;
     private Long price;
     private String description;
-    private String meetingPlace;
+    private String basicAddress;
+    private String detailedAddress;
     private final String addedDate;
     private String status;
     private final UserResponse user;

--- a/src/main/java/com/market/saessag/domain/product/entity/Product.java
+++ b/src/main/java/com/market/saessag/domain/product/entity/Product.java
@@ -33,7 +33,13 @@ public class Product {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    private String meetingPlace;
+    private Double latitude;
+
+    private Double longitude;
+
+    private String basicAddress;
+
+    private String detailedAddress;
 
     private LocalDateTime addedDate;
 

--- a/src/main/java/com/market/saessag/domain/product/service/ProductService.java
+++ b/src/main/java/com/market/saessag/domain/product/service/ProductService.java
@@ -33,22 +33,28 @@ public class ProductService {
         product.setTitle(productRequest.getTitle());
         product.setPrice(productRequest.getPrice());
         product.setDescription(productRequest.getDescription());
-        product.setMeetingPlace(productRequest.getMeetingPlace());
+        product.setLatitude(productRequest.getLatitude());
+        product.setLongitude(productRequest.getLongitude());
+        product.setBasicAddress(productRequest.getBasicAddress());
+        product.setDetailedAddress(productRequest.getDetailedAddress());
         product.setPhoto(productRequest.getPhoto());
         product.setStatus(Product.ProductStatus.valueOf(productRequest.getStatus()));
         return convertToDTO(productRepository.save(product));
     }
 
     //상품 수정
-    public ProductResponse updateProduct(Long productId, Product product) {
+    public ProductResponse updateProduct(Long productId, ProductRequest productRequest) {
         Product productDTO = productRepository.findById(productId)
                 .map(afterProduct -> {
-                    afterProduct.setDescription(product.getDescription());
-                    afterProduct.setMeetingPlace(product.getMeetingPlace());
-                    afterProduct.setPhoto(product.getPhoto());
-                    afterProduct.setPrice(product.getPrice());
-                    afterProduct.setStatus(product.getStatus());
-                    afterProduct.setTitle(product.getTitle());
+                    afterProduct.setDescription(productRequest.getDescription());
+                    afterProduct.setLatitude(productRequest.getLatitude());
+                    afterProduct.setLongitude(productRequest.getLongitude());
+                    afterProduct.setBasicAddress(productRequest.getBasicAddress());
+                    afterProduct.setDetailedAddress(productRequest.getDetailedAddress());
+                    afterProduct.setPhoto(productRequest.getPhoto());
+                    afterProduct.setPrice(productRequest.getPrice());
+                    afterProduct.setStatus(Product.ProductStatus.valueOf(productRequest.getStatus()));
+                    afterProduct.setTitle(productRequest.getTitle());
                     return productRepository.save(afterProduct);
                 }).orElseThrow(() -> new IllegalArgumentException("없는 상품 번호 입니다."));
 
@@ -86,7 +92,8 @@ public class ProductService {
                 .title(product.getTitle())
                 .price(product.getPrice())
                 .description(product.getDescription())
-                .meetingPlace(product.getMeetingPlace())
+                .basicAddress(product.getBasicAddress())
+                .detailedAddress(product.getDetailedAddress())
                 .addedDate(TimeUtils.getRelativeTime(product.getAddedDate()))
                 .status(product.getStatus().toString())
                 .user(UserResponse.builder()


### PR DESCRIPTION
## #️⃣ Issue Number

#44 

## 📝 작업 설명

지도 위치 저장 기능을 구현했습니다.
카카오 맵에서 좌표 선택 시 결정 된 위도, 경도, 도로명 주소 정보 받아서 상품 테이블에 저장합니다.
좌표 선택 후 입력 하는 상세 주소 상품 테이블에 저장합니다.

## 📸스크린샷 (선택)   

## 💬 리뷰 요구사항

상품 테이블에서 필요한 기능을 먼저 만들어야 할 것 같아서 기능만 우선적으로 만들었습니다.
머지 먼저 한 후 리팩토링 브랜치 생성해서 다시 작업 하겠습니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).