### PR TITLE
RequestContextHolder를 이용한 세션 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	implementation 'software.amazon.awssdk:core:2.20.0'
 	implementation 'software.amazon.awssdk:auth:2.20.0'
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+	implementation 'org.springframework:spring-web'
+
 }
 
 test {

--- a/src/main/java/com/market/saessag/global/config/WebConfig.java
+++ b/src/main/java/com/market/saessag/global/config/WebConfig.java
@@ -1,0 +1,14 @@
+package com.market.saessag.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextListener;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Bean
+    public RequestContextListener requestContextListener() {
+        return new RequestContextListener();
+    }
+}

--- a/src/main/java/com/market/saessag/global/config/WebConfig.java
+++ b/src/main/java/com/market/saessag/global/config/WebConfig.java
@@ -1,14 +1,30 @@
 package com.market.saessag.global.config;
 
+import com.market.saessag.global.interceptor.SessionInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.RequestContextListener;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+    @Autowired
+    private SessionInterceptor sessionInterceptor;
     @Bean
     public RequestContextListener requestContextListener() {
         return new RequestContextListener();
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(sessionInterceptor)
+                .addPathPatterns("/**")        // 모든 경로에 인터셉터 적용
+                .excludePathPatterns(          // 제외할 경로 설정
+                        "/api/sign-up",
+                        "/api/sign-in",
+                        "/error"
+                );
     }
 }

--- a/src/main/java/com/market/saessag/global/config/WebConfig.java
+++ b/src/main/java/com/market/saessag/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.market.saessag.global.config;
 
 import com.market.saessag.global.interceptor.SessionInterceptor;
+import com.market.saessag.global.util.PathConst;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,10 +22,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(sessionInterceptor)
                 .addPathPatterns("/**")        // 모든 경로에 인터셉터 적용
-                .excludePathPatterns(          // 제외할 경로 설정
-                        "/api/sign-up",
-                        "/api/sign-in",
-                        "/error"
-                );
+                .excludePathPatterns(PathConst.EXCLUDED_PATHS); // 제외할 경로 설정
     }
 }

--- a/src/main/java/com/market/saessag/global/exception/ErrorCode.java
+++ b/src/main/java/com/market/saessag/global/exception/ErrorCode.java
@@ -2,20 +2,25 @@ package com.market.saessag.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    DUPLICATE_EMAIL(400, "이미 가입된 이메일입니다"),
-    VERIFICATION_EXPIRED(400, "인증 시간이 만료되었습니다"),
-    INVALID_VERIFICATION_CODE(400, "잘못된 인증 코드입니다"),
-    EMAIL_NOT_VERIFIED(400, "이메일 인증이 필요합니다. 먼저 이메일 인증을 완료해주세요."),
-    USER_NOT_FOUND(404, "존재하지 않는 사용자입니다"),
-    EMAIL_SEND_FAILED(500, "이메일 발송에 실패했습니다"),
-    INVALID_EMAIL(400, "유효하지 않은 이메일입니다"),
-    INVALID_PASSWORD(400, "현재 비밀번호가 일치하지 않습니다");
+    DUPLICATE_EMAIL(HttpStatus.UNAUTHORIZED, "이미 가입된 이메일입니다"),
+    VERIFICATION_EXPIRED(HttpStatus.UNAUTHORIZED, "인증 시간이 만료되었습니다"),
+    INVALID_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED, "잘못된 인증 코드입니다"),
+    EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "이메일 인증이 필요합니다. 먼저 이메일 인증을 완료해주세요."),
+    USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자입니다"),
+    EMAIL_SEND_FAILED(HttpStatus.UNAUTHORIZED, "이메일 발송에 실패했습니다"),
+    INVALID_EMAIL(HttpStatus.UNAUTHORIZED, "유효하지 않은 이메일입니다"),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 일치하지 않습니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
+    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
 
-    private final int status;
+    private final HttpStatus  status;
     private final String message;
 
 }

--- a/src/main/java/com/market/saessag/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/market/saessag/global/exception/GlobalExceptionHandler.java
@@ -1,38 +1,39 @@
 package com.market.saessag.global.exception;
 
 import com.market.saessag.global.response.ErrorResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpSessionRequiredException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .message(e.getMessage())
-                .status(HttpStatus.BAD_REQUEST.value())
-                .build();
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(errorResponse);
+    // 1. 세션 관련 예외를 먼저 처리
+    @ExceptionHandler(HttpSessionRequiredException.class)
+    public ResponseEntity<ErrorResponse> handleSessionException(HttpSessionRequiredException e) {
+        ErrorResponse response = ErrorResponse.of(ErrorCode.UNAUTHORIZED);
+        return ResponseEntity.status(response.getStatus()).body(response);
     }
 
-    // 공통된 예외 처리
+    // 2. IllegalArgumentException 처리
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_ARGUMENT);
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    // 3. 공통된 예외 처리
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         ErrorResponse response = ErrorResponse.of(e.getErrorCode());
         return ResponseEntity.status(response.getStatus()).body(response);
     }
 
-    // 기타 서버 예외 처리
+    // 4. 기타 서버 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
-        ErrorResponse response = ErrorResponse.builder()
-                .message("서버 내부 오류가 발생했습니다")
-                .status(500)
-                .build();
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return ResponseEntity.status(response.getStatus()).body(response);
     }
 

--- a/src/main/java/com/market/saessag/global/interceptor/SessionInterceptor.java
+++ b/src/main/java/com/market/saessag/global/interceptor/SessionInterceptor.java
@@ -2,6 +2,7 @@ package com.market.saessag.global.interceptor;
 
 import com.market.saessag.global.exception.CustomException;
 import com.market.saessag.global.exception.ErrorCode;
+import com.market.saessag.global.util.PathConst;
 import com.market.saessag.global.util.SessionUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -12,17 +13,10 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class SessionInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-        // 로그인 없이 접근 가능한 API 경로
-        String[] allowedUrls = {
-                "/api/sign-up",    // 회원가입 API
-                "/api/sign-in",    // 로그인 API
-                "/error"           // 에러 페이지
-        };
-
         String requestUrl = request.getRequestURI();
 
-        // 허용된 URL은 인터셉터를 통과
-        for (String url : allowedUrls) {
+        // PathConst의 허용된 URL 목록 사용
+        for (String url : PathConst.EXCLUDED_PATHS) {
             if (requestUrl.startsWith(url)) {
                 return true;
             }

--- a/src/main/java/com/market/saessag/global/interceptor/SessionInterceptor.java
+++ b/src/main/java/com/market/saessag/global/interceptor/SessionInterceptor.java
@@ -1,0 +1,36 @@
+package com.market.saessag.global.interceptor;
+
+import com.market.saessag.global.util.SessionUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class SessionInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // 로그인 없이 접근 가능한 API 경로
+        String[] allowedUrls = {
+                "/api/sign-up",    // 회원가입 API
+                "/api/sign-in",    // 로그인 API
+                "/error"           // 에러 페이지
+        };
+
+        String requestUrl = request.getRequestURI();
+
+        // 허용된 URL은 인터셉터를 통과
+        for (String url : allowedUrls) {
+            if (requestUrl.startsWith(url)) {
+                return true;
+            }
+        }
+
+        // 그 외의 URL은 세션 체크
+        if (SessionUtil.getData("user") == null) {
+            response.sendRedirect("/api/sign-in");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/market/saessag/global/interceptor/SessionInterceptor.java
+++ b/src/main/java/com/market/saessag/global/interceptor/SessionInterceptor.java
@@ -1,5 +1,7 @@
 package com.market.saessag.global.interceptor;
 
+import com.market.saessag.global.exception.CustomException;
+import com.market.saessag.global.exception.ErrorCode;
 import com.market.saessag.global.util.SessionUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,10 +28,9 @@ public class SessionInterceptor implements HandlerInterceptor {
             }
         }
 
-        // 그 외의 URL은 세션 체크
+        // 그 외의 URL은 세션 체크 후 에러 처리
         if (SessionUtil.getData("user") == null) {
-            response.sendRedirect("/api/sign-in");
-            return false;
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
         return true;
     }

--- a/src/main/java/com/market/saessag/global/response/ErrorResponse.java
+++ b/src/main/java/com/market/saessag/global/response/ErrorResponse.java
@@ -2,6 +2,7 @@ package com.market.saessag.global.response;
 
 import com.market.saessag.global.exception.ErrorCode;
 import lombok.*;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Builder
@@ -9,7 +10,7 @@ import lombok.*;
 @AllArgsConstructor
 public class ErrorResponse {
     private String message;
-    private int status;
+    private HttpStatus status;
 
     public static ErrorResponse of(ErrorCode errorCode) {
         return ErrorResponse.builder()

--- a/src/main/java/com/market/saessag/global/util/PathConst.java
+++ b/src/main/java/com/market/saessag/global/util/PathConst.java
@@ -1,0 +1,12 @@
+package com.market.saessag.global.util;
+
+// 제외할 경로 공통 상수 클래스
+public class PathConst {
+    public static final String[] EXCLUDED_PATHS = {
+            "/api/sign-up",
+            "/api/sign-in",
+            "/error"
+    };
+
+    private PathConst() {} // 인스턴스화 방지
+}

--- a/src/main/java/com/market/saessag/global/util/SessionUtil.java
+++ b/src/main/java/com/market/saessag/global/util/SessionUtil.java
@@ -1,0 +1,36 @@
+package com.market.saessag.global.util;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class SessionUtil {
+    // 세션 가져오기
+    public static HttpSession getSession() {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        return attributes.getRequest().getSession();
+    }
+
+    // 세션에 데이터 저장
+    public static void setData(String key, Object value) {
+        getSession().setAttribute(key, value);
+    }
+
+    // 세션에서 데이터 가져오기
+    public static Object getData(String key) {
+        return getSession().getAttribute(key);
+    }
+
+    // 특정 세션 삭제
+    public static void removeData(String key) {
+        getSession().removeAttribute(key);
+    }
+
+    // 모든 세션 삭제
+    public static void clear() {
+        getSession().invalidate();
+    }
+}
+


### PR DESCRIPTION
## #️⃣ Issue Number

#57 

## 📝 작업 설명
- RequestContextHolder를 이용해서 세션 관리를 합니다.
매번 httpSession를 매개변수로 받지 않고, 세션을 가져올 수 있습니다.

- 세션 인터셉터를 설정하여 로그인 없이 접근 가능한 페이지를 설정했습니다.
회원가입, 로그인, 에러 페이지는 로그인 없이 접근이 가능합니다.

- HTTP 상태 코드 타입을 int에서 HttpStatus로 변경했습니다.

- 세션 관련 예외처리를 했습니다.


## 📸스크린샷 (선택)   
로그인을 하지 않거나, 로그인 세션이 만료되면 아래와 같은 에러로 처리됩니다.
![image](https://github.com/user-attachments/assets/28805635-2c76-4a63-934c-e5dbc2de7d65)


## 💬 리뷰 요구사항


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
