### PR TITLE
상품 조회 오류 및 끌어올리기 수정

### DIFF
--- a/src/main/java/com/market/saessag/domain/product/controller/ProductController.java
+++ b/src/main/java/com/market/saessag/domain/product/controller/ProductController.java
@@ -100,9 +100,8 @@ public class ProductController {
     }
 
     @PostMapping("/bump")
-    public ApiResponse<?> bumpProduct(@RequestParam Long productId, HttpServletRequest session) {
-        SignInResponse signInResponse = (SignInResponse) session.getAttribute("user");
-        Product product = productService.bumpProduct(productId, signInResponse.getId());
+    public ApiResponse<?> bumpProduct(@RequestParam Long productId, @SessionAttribute(name = "user") SignInResponse user) {
+        Product product = productService.bumpProduct(productId, user.getId());
         return ApiResponse.builder()
             .status("200")
             .data(product.getId())

--- a/src/main/java/com/market/saessag/domain/product/service/ProductService.java
+++ b/src/main/java/com/market/saessag/domain/product/service/ProductService.java
@@ -82,8 +82,8 @@ public class ProductService {
     public Page<ProductResponse> searchProducts(int page, int size, String title, String nickname, String sort) {
         Sort sorting = (sort == null || sort.isEmpty()) ?
             Sort.by(
-                Sort.Order.desc("dump_at").nullsLast(),
-                Sort.Order.desc("added_date")
+                Sort.Order.desc("bumpAt"),
+                Sort.Order.desc("addedDate")
             ) : Sort.by(Sort.Order.by(sort));
 
         Pageable pageable = PageRequest.of(page, size, sorting);


### PR DESCRIPTION
## #️⃣ Issue Number

#62 

## 📝 작업 설명

끌어올리기 요청 시 유저 세션 값을 얻지 못해 @SessionAttribute를 사용하는 방식으로 수정했습니다.
상품 조회 시 정렬 로직에 있던 nullsLast()는 MySQL에서 지원하지 않아 삭제했습니다. (기본으로 적용되어 있음)

## 📸스크린샷 (선택)   

## 💬 리뷰 요구사항


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
