### PR TITLE
updatedAt 필드를 이용한 최신 업데이트 순 정렬 구현

### DIFF
--- a/src/main/java/com/market/saessag/domain/product/controller/ProductController.java
+++ b/src/main/java/com/market/saessag/domain/product/controller/ProductController.java
@@ -4,7 +4,6 @@ import com.market.saessag.domain.product.dto.ProductChangeStatusRequest;
 import com.market.saessag.domain.product.dto.ProductChangeStatusResponse;
 import com.market.saessag.domain.product.dto.ProductRequest;
 import com.market.saessag.domain.product.dto.ProductResponse;
-import com.market.saessag.domain.product.entity.Product;
 import com.market.saessag.domain.product.service.ProductService;
 import com.market.saessag.domain.user.dto.SignInResponse;
 import com.market.saessag.global.exception.CustomException;
@@ -109,27 +108,16 @@ public class ProductController {
     // 상품 끌어올리기
     // @PreAuthorize("isAuthenticated()")  인증된 사용자만 접근 가능한 시큐리티의 메서드 방식 --> 나중에 리팩토링
     @PostMapping("/bump/{id}")
-    public ApiResponse<?> bumpProduct(@PathVariable Long id, HttpServletRequest request) {
-        // 1. 세션 확인
-        HttpSession session = request.getSession();
-        SignInResponse userSession = (SignInResponse) session.getAttribute("userProfile");
-
-        if (userSession == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        // 2. 서비스 호출 (소유자 검증은 서비스에서 처리)
-        Product bumpedProduct = productService.bumpProduct(id, userSession.getId());
-        return ApiResponse.success(SuccessCode.OK, bumpedProduct.getId());
+    public ApiResponse<ProductResponse> bumpProduct(@PathVariable Long id, HttpServletRequest httpRequest) {
+        ProductResponse bumpedProduct = productService.bumpProduct(id, httpRequest);
+        return ApiResponse.success(SuccessCode.OK, bumpedProduct);
     }
+
 
     // 상품 상태 값 변경(본인 소유의 상품의 상태 값만 변경 가능)
     @PostMapping("/changeStatus")
-    public ApiResponse<ProductChangeStatusResponse> changeStatus(
-            @RequestBody ProductChangeStatusRequest req,
-            HttpServletRequest request) {
+    public ApiResponse<ProductChangeStatusResponse> changeStatus(@RequestBody ProductChangeStatusRequest req, HttpServletRequest request) {
         ProductChangeStatusResponse response = productService.changeStatus(req, request);
         return ApiResponse.success(SuccessCode.OK, response);
     }
-
 }

--- a/src/main/java/com/market/saessag/domain/product/dto/ProductRequest.java
+++ b/src/main/java/com/market/saessag/domain/product/dto/ProductRequest.java
@@ -1,10 +1,15 @@
 package com.market.saessag.domain.product.dto;
 
-import lombok.Getter;
-
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProductRequest {
     private String title;
     private Long price;

--- a/src/main/java/com/market/saessag/domain/product/entity/Product.java
+++ b/src/main/java/com/market/saessag/domain/product/entity/Product.java
@@ -44,6 +44,8 @@ public class Product {
 
     private LocalDateTime addedDate;
 
+    private LocalDateTime updatedAt; // 수정 시점
+
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
 
@@ -80,6 +82,9 @@ public class Product {
         this.status = status;
     }
 
+    public void updateUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
     public void updateBumpAt(LocalDateTime bumpAt) {
         this.bumpAt = bumpAt;
     }

--- a/src/main/java/com/market/saessag/domain/product/entity/Product.java
+++ b/src/main/java/com/market/saessag/domain/product/entity/Product.java
@@ -63,6 +63,8 @@ public class Product {
         this.status = status;
     }
 
+    // 끌어올리기 전용 메서드
+    public void bump() { this.updatedAt = LocalDateTime.now(); }
 
     // 상품 생성(정적 팩토리 메서드)
     public static Product createProduct(User user, ProductRequest request) {

--- a/src/main/java/com/market/saessag/domain/product/entity/Product.java
+++ b/src/main/java/com/market/saessag/domain/product/entity/Product.java
@@ -1,5 +1,6 @@
 package com.market.saessag.domain.product.entity;
 
+import com.market.saessag.domain.product.dto.ProductRequest;
 import com.market.saessag.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -49,9 +50,6 @@ public class Product {
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
 
-    private LocalDateTime bumpAt;
-
-
     public enum ProductStatus {
         FOR_SALE, HIDDEN, SOLD_OUT
     }
@@ -61,27 +59,39 @@ public class Product {
         this.addedDate = LocalDateTime.now(); // 현재 시간 자동 설정
     }
 
-    public void updateProduct(String title, Long price, String description, List<String> photo,
-                              Double latitude, Double longitude, String basicAddress, String detailedAddress, ProductStatus status) {
-        this.title = title;
-        this.price = price;
-        this.description = description;
-        this.photo = photo;
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.basicAddress = basicAddress;
-        this.detailedAddress = detailedAddress;
-        this.status = status;
-    }
-
-    public void updateUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-    public void updateBumpAt(LocalDateTime bumpAt) {
-        this.bumpAt = bumpAt;
-    }
-
     public void updateStatus(ProductStatus status) {
         this.status = status;
+    }
+
+
+    // 상품 생성(정적 팩토리 메서드)
+    public static Product createProduct(User user, ProductRequest request) {
+        Product product = new Product();
+        product.user = user;
+        product.title = request.getTitle();
+        product.price = request.getPrice();
+        product.description = request.getDescription();
+        product.photo = request.getPhoto();
+        product.latitude = request.getLatitude();
+        product.longitude = request.getLongitude();
+        product.basicAddress = request.getBasicAddress();
+        product.detailedAddress = request.getDetailedAddress();
+        product.status = ProductStatus.valueOf(request.getStatus());
+        product.updatedAt = LocalDateTime.now();
+        return product;
+    }
+
+    // 상품 정보 수정(정적 팩토리 메서드)
+    public void updateProduct(ProductRequest request) {
+        this.title = request.getTitle();
+        this.price = request.getPrice();
+        this.description = request.getDescription();
+        this.photo = request.getPhoto();
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+        this.basicAddress = request.getBasicAddress();
+        this.detailedAddress = request.getDetailedAddress();
+        this.status = ProductStatus.valueOf(request.getStatus());
+        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/market/saessag/domain/product/service/ProductService.java
+++ b/src/main/java/com/market/saessag/domain/product/service/ProductService.java
@@ -28,8 +28,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class ProductService {
@@ -56,6 +54,7 @@ public class ProductService {
         User user = userRepository.findById(userSession.getId())
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
+        LocalDateTime now = LocalDateTime.now();
         Product product = Product.builder()
                 .user(user)
                 .title(productRequest.getTitle())
@@ -67,6 +66,8 @@ public class ProductService {
                 .detailedAddress(productRequest.getDetailedAddress())
                 .photo(productRequest.getPhoto())
                 .status(Product.ProductStatus.valueOf(productRequest.getStatus()))
+                .bumpAt(now)
+                .updatedAt(now)
                 .build();
         return convertToDTO(productRepository.save(product));
     }
@@ -128,12 +129,13 @@ public class ProductService {
         }
     }
 
+    // 상품 검색, 필터링, 정렬
     public Page<ProductResponse> searchProducts(int page, int size, String title, String nickname, String sort) {
         try {
             Sort sorting = (sort == null || sort.isEmpty()) ?
                 Sort.by(
-                    Sort.Order.desc("bumpAt"),
-                    Sort.Order.desc("addedDate")
+                    Sort.Order.desc("updatedAt"),  // 최신 업데이트 순
+                    Sort.Order.desc("bumpAt")      // 끌어올리기 순
                 ) : Sort.by(Sort.Order.by(sort));
 
             Pageable pageable = PageRequest.of(page, size, sorting);
@@ -197,7 +199,9 @@ public class ProductService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
 
-        product.updateBumpAt(LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        product.updateBumpAt(now);
+        product.updateUpdatedAt(now);
         return productRepository.save(product);
     }
 

--- a/src/main/java/com/market/saessag/domain/product/service/ProductService.java
+++ b/src/main/java/com/market/saessag/domain/product/service/ProductService.java
@@ -171,20 +171,7 @@ public class ProductService {
         User user = getUserFromSession(httpRequest);
         Product product = getProductAndValidateOwner(productId, user.getId());
 
-        // 기존 상품 정보로 ProductRequest 생성
-        ProductRequest request = ProductRequest.builder()
-                .title(product.getTitle())
-                .price(product.getPrice())
-                .description(product.getDescription())
-                .photo(product.getPhoto())
-                .latitude(product.getLatitude())
-                .longitude(product.getLongitude())
-                .basicAddress(product.getBasicAddress())
-                .detailedAddress(product.getDetailedAddress())
-                .status(product.getStatus().toString())
-                .build();
-
-        product.updateProduct(request);
+        product.bump();  // updatedAt만 갱신
         return convertToDTO(productRepository.save(product));
     }
 

--- a/src/main/java/com/market/saessag/domain/product/service/ProductService.java
+++ b/src/main/java/com/market/saessag/domain/product/service/ProductService.java
@@ -20,7 +20,6 @@ import com.market.saessag.util.TimeUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -42,65 +41,19 @@ public class ProductService {
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
     }
 
-    //상품 생성
-    public ProductResponse createProduct(ProductRequest productRequest, HttpServletRequest request) {
-        HttpSession session = request.getSession();
-        SignInResponse userSession = (SignInResponse) session.getAttribute("userProfile");
-
-        if (userSession == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        User user = userRepository.findById(userSession.getId())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-        LocalDateTime now = LocalDateTime.now();
-        Product product = Product.builder()
-                .user(user)
-                .title(productRequest.getTitle())
-                .price(productRequest.getPrice())
-                .description(productRequest.getDescription())
-                .latitude(productRequest.getLatitude())
-                .longitude(productRequest.getLongitude())
-                .basicAddress(productRequest.getBasicAddress())
-                .detailedAddress(productRequest.getDetailedAddress())
-                .photo(productRequest.getPhoto())
-                .status(Product.ProductStatus.valueOf(productRequest.getStatus()))
-                .bumpAt(now)
-                .updatedAt(now)
-                .build();
+    // 상품 생성
+    public ProductResponse createProduct(ProductRequest request, HttpServletRequest httpRequest) {
+        User user = getUserFromSession(httpRequest);
+        Product product = Product.createProduct(user, request);
         return convertToDTO(productRepository.save(product));
     }
 
+    // 상품 수정
+    public ProductResponse updateProduct(Long productId, ProductRequest request, HttpServletRequest httpRequest) {
+        User user = getUserFromSession(httpRequest);
+        Product product = getProductAndValidateOwner(productId, user.getId());
 
-    //상품 수정
-    public ProductResponse updateProduct(Long productId, ProductRequest productRequest, HttpServletRequest request) {
-        HttpSession session = request.getSession();
-        SignInResponse userSession = (SignInResponse) session.getAttribute("userProfile");
-
-        if (userSession == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("없는 상품 번호 입니다."));
-
-        // 글쓴이와 현재 로그인한 사용자가 같은지 확인
-        if (!product.getUser().getId().equals(userSession.getId())) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-
-        product.updateProduct(
-                productRequest.getTitle(),
-                productRequest.getPrice(),
-                productRequest.getDescription(),
-                productRequest.getPhoto(),
-                productRequest.getLatitude(),
-                productRequest.getLongitude(),
-                productRequest.getBasicAddress(),
-                productRequest.getDetailedAddress(),
-                Product.ProductStatus.valueOf(productRequest.getStatus()));
-
+        product.updateProduct(request);
         return convertToDTO(productRepository.save(product));
     }
 
@@ -134,8 +87,7 @@ public class ProductService {
         try {
             Sort sorting = (sort == null || sort.isEmpty()) ?
                 Sort.by(
-                    Sort.Order.desc("updatedAt"),  // 최신 업데이트 순
-                    Sort.Order.desc("bumpAt")      // 끌어올리기 순
+                    Sort.Order.desc("updatedAt")  // 최신 업데이트 순
                 ) : Sort.by(Sort.Order.by(sort));
 
             Pageable pageable = PageRequest.of(page, size, sorting);
@@ -183,6 +135,31 @@ public class ProductService {
                 .build();
     }
 
+    // 세션에서 사용자 정보를 가져와서 검증
+    private User getUserFromSession(HttpServletRequest request) {
+        HttpSession session = request.getSession();
+        SignInResponse userSession = (SignInResponse) session.getAttribute("userProfile");
+
+        if (userSession == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return userRepository.findById(userSession.getId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    }
+
+    // 상품을 찾고 해당 상품의 소유자가 맞는지 검증
+    private Product getProductAndValidateOwner(Long productId, Long userId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        if (!product.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        return product;
+    }
+
     public ProductResponse getProductDetail(Long productId) {
         Product id = productRepository.findById(productId)
                 .orElseThrow(()-> new IllegalArgumentException("상품이 없습니다."));
@@ -190,19 +167,25 @@ public class ProductService {
     }
 
     // 상품 끌어올리기
-    public Product bumpProduct(Long productId, Long userId) {
-        Product product = productRepository.findById(productId)
-            .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
+    public ProductResponse bumpProduct(Long productId, HttpServletRequest httpRequest) {
+        User user = getUserFromSession(httpRequest);
+        Product product = getProductAndValidateOwner(productId, user.getId());
 
-        // 상품 소유자 검증
-        if (!product.getUser().getId().equals(userId)) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
+        // 기존 상품 정보로 ProductRequest 생성
+        ProductRequest request = ProductRequest.builder()
+                .title(product.getTitle())
+                .price(product.getPrice())
+                .description(product.getDescription())
+                .photo(product.getPhoto())
+                .latitude(product.getLatitude())
+                .longitude(product.getLongitude())
+                .basicAddress(product.getBasicAddress())
+                .detailedAddress(product.getDetailedAddress())
+                .status(product.getStatus().toString())
+                .build();
 
-        LocalDateTime now = LocalDateTime.now();
-        product.updateBumpAt(now);
-        product.updateUpdatedAt(now);
-        return productRepository.save(product);
+        product.updateProduct(request);
+        return convertToDTO(productRepository.save(product));
     }
 
     // 조회수 증가
@@ -250,23 +233,12 @@ public class ProductService {
     }
 
     // 상품 상태 값 변경
-    public ProductChangeStatusResponse changeStatus(ProductChangeStatusRequest req, HttpServletRequest request) {
-        HttpSession session = request.getSession();
-        SignInResponse userSession = (SignInResponse) session.getAttribute("userProfile");
-
-        if (userSession == null) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
-
-        Product product = productRepository.findById(req.getId())
-                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
-
-        if (!product.getUser().getId().equals(userSession.getId())) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
+    public ProductChangeStatusResponse changeStatus(ProductChangeStatusRequest request, HttpServletRequest httpRequest) {
+        User user = getUserFromSession(httpRequest);
+        Product product = getProductAndValidateOwner(request.getId(), user.getId());
 
         try {
-            product.updateStatus(req.getStatus());
+            product.updateStatus(request.getStatus());
             Product savedProduct = productRepository.save(product);
 
             return ProductChangeStatusResponse.builder()
@@ -277,5 +249,4 @@ public class ProductService {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
-
 }

--- a/src/test/java/com/market/saessag/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/market/saessag/domain/product/service/ProductServiceTest.java
@@ -2,13 +2,19 @@ package com.market.saessag.domain.product.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.market.saessag.domain.product.dto.ProductRequest;
+import com.market.saessag.domain.product.dto.ProductResponse;
 import com.market.saessag.domain.product.entity.Product;
 import com.market.saessag.domain.product.repository.ProductRepository;
+import com.market.saessag.domain.user.dto.SignInResponse;
 import com.market.saessag.domain.user.entity.User;
+import com.market.saessag.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,11 +24,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceTest {
-
   @InjectMocks
   private ProductService productService;
+
   @Mock
   private ProductRepository productRepository;
+  @Mock
+  private UserRepository userRepository;
 
   @Test
   void bumpProduct() {
@@ -40,18 +48,26 @@ class ProductServiceTest {
             .user(user)
             .build();
 
-    when(productRepository.findById(anyLong()))
-            .thenReturn(Optional.of(product));
-    when(productRepository.save(any(Product.class)))
-            .thenReturn(product);  // save에 대한 mock 동작 추가
+    HttpServletRequest httpRequest = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    SignInResponse userSession = new SignInResponse(user.getId(), user.getProfileUrl(), user.getEmail(), user.getNickname());
+
+    // 모킹 설정
+    when(httpRequest.getSession()).thenReturn(session);
+    when(session.getAttribute("userProfile")).thenReturn(userSession);
+    when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+    when(productRepository.findById(product.getId())).thenReturn(Optional.of(product));
+    when(productRepository.save(any(Product.class))).thenReturn(product);
 
     // when
-    Product newProduct = productService.bumpProduct(product.getId(), user.getId());
+    ProductResponse response = productService.bumpProduct(product.getId(), httpRequest);
 
     // then
-    assertNotNull(newProduct);
-    assertEquals(product.getId(), newProduct.getId());
-    assertNotNull(newProduct.getBumpAt());
-    verify(productRepository).save(newProduct);
+    assertNotNull(response);
+    assertEquals(product.getId(), response.getProductId());
+    assertNotNull(product.getUpdatedAt());
+    verify(productRepository).findById(product.getId());
+    verify(productRepository).save(product);
+    verify(userRepository).findById(user.getId());
   }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#80 

## 📝 작업 설명

updatedAt 필드를 이용해서 가장 최근에 변경된 상품이 가장 위에 올라오도록 구현했습니다.

## 📸스크린샷 (선택)   

## 💬 리뷰 요구사항

원래 bumpAt, addedDate 필드를 이용해서 정렬을 했었는데, 이때 새 상품 생성을 하면 끌어올리기 밑으로 상품이 생성되는 문제가 있었습니다.
updatedAt 필드를 이용한다면 새 상품 생성 시에도 끌어올리기 위로 상품이 생성됩니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
