### PR TITLE
유저 관련 세션 인증/인가 처리 및 응답 형식 통일화

### DIFF
--- a/src/main/java/com/market/saessag/domain/email/controller/PasswordController.java
+++ b/src/main/java/com/market/saessag/domain/email/controller/PasswordController.java
@@ -3,8 +3,8 @@ package com.market.saessag.domain.email.controller;
 import com.market.saessag.domain.email.dto.EmailRequest;
 import com.market.saessag.domain.email.dto.PasswordChangeRequest;
 import com.market.saessag.domain.email.service.PasswordService;
-import com.market.saessag.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,15 +14,16 @@ import org.springframework.web.bind.annotation.*;
 public class PasswordController {
     private final PasswordService passwordService;
 
-    // 비밀번호 찾기
     @PostMapping("/find")
-    public ApiResponse<String> findPassword(@RequestBody @Validated EmailRequest request) {
-        return passwordService.sendTemporaryPassword(request.getEmail()); // 이메일로 임시 비밀번호 발급
+    public ResponseEntity<?> findPassword(@RequestBody @Validated EmailRequest request) {
+        // 이메일로 임시 비밀번호 발급
+        passwordService.sendTemporaryPassword(request.getEmail());
+        return ResponseEntity.ok("임시 비밀번호가 이메일로 발송되었습니다."); // 응답 포맷 통일 필요함
     }
 
-    // 비밀번호 변경
     @PatchMapping("/change")
-    public ApiResponse<String> changePassword(@RequestBody @Validated PasswordChangeRequest request) {
-        return passwordService.changePassword(request);
+    public ResponseEntity<?> changePassword(@RequestBody @Validated PasswordChangeRequest request) {
+        passwordService.changePassword(request);
+        return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다."); // 응답 포맷 통일 필요함
     }
 }

--- a/src/main/java/com/market/saessag/domain/email/controller/PasswordController.java
+++ b/src/main/java/com/market/saessag/domain/email/controller/PasswordController.java
@@ -3,8 +3,8 @@ package com.market.saessag.domain.email.controller;
 import com.market.saessag.domain.email.dto.EmailRequest;
 import com.market.saessag.domain.email.dto.PasswordChangeRequest;
 import com.market.saessag.domain.email.service.PasswordService;
+import com.market.saessag.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,16 +14,15 @@ import org.springframework.web.bind.annotation.*;
 public class PasswordController {
     private final PasswordService passwordService;
 
+    // 비밀번호 찾기
     @PostMapping("/find")
-    public ResponseEntity<?> findPassword(@RequestBody @Validated EmailRequest request) {
-        // 이메일로 임시 비밀번호 발급
-        passwordService.sendTemporaryPassword(request.getEmail());
-        return ResponseEntity.ok("임시 비밀번호가 이메일로 발송되었습니다."); // 응답 포맷 통일 필요함
+    public ApiResponse<String> findPassword(@RequestBody @Validated EmailRequest request) {
+        return passwordService.sendTemporaryPassword(request.getEmail()); // 이메일로 임시 비밀번호 발급
     }
 
+    // 비밀번호 변경
     @PatchMapping("/change")
-    public ResponseEntity<?> changePassword(@RequestBody @Validated PasswordChangeRequest request) {
-        passwordService.changePassword(request);
-        return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다."); // 응답 포맷 통일 필요함
+    public ApiResponse<String> changePassword(@RequestBody @Validated PasswordChangeRequest request) {
+        return passwordService.changePassword(request);
     }
 }

--- a/src/main/java/com/market/saessag/domain/email/controller/PasswordController.java
+++ b/src/main/java/com/market/saessag/domain/email/controller/PasswordController.java
@@ -3,8 +3,9 @@ package com.market.saessag.domain.email.controller;
 import com.market.saessag.domain.email.dto.EmailRequest;
 import com.market.saessag.domain.email.dto.PasswordChangeRequest;
 import com.market.saessag.domain.email.service.PasswordService;
+import com.market.saessag.global.response.ApiResponse;
+import com.market.saessag.global.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,16 +15,17 @@ import org.springframework.web.bind.annotation.*;
 public class PasswordController {
     private final PasswordService passwordService;
 
+    // 비밀번호 찾기
     @PostMapping("/find")
-    public ResponseEntity<?> findPassword(@RequestBody @Validated EmailRequest request) {
-        // 이메일로 임시 비밀번호 발급
+    public ApiResponse<String> findPassword(@RequestBody @Validated EmailRequest request) {
         passwordService.sendTemporaryPassword(request.getEmail());
-        return ResponseEntity.ok("임시 비밀번호가 이메일로 발송되었습니다."); // 응답 포맷 통일 필요함
+        return ApiResponse.success(SuccessCode.TEMP_PASSWORD_SENT);
     }
 
+    // 비밀번호 변경
     @PatchMapping("/change")
-    public ResponseEntity<?> changePassword(@RequestBody @Validated PasswordChangeRequest request) {
+    public ApiResponse<String> changePassword(@RequestBody @Validated PasswordChangeRequest request) {
         passwordService.changePassword(request);
-        return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다."); // 응답 포맷 통일 필요함
+        return ApiResponse.success(SuccessCode.PASSWORD_CHANGED);
     }
 }

--- a/src/main/java/com/market/saessag/domain/email/service/EmailService.java
+++ b/src/main/java/com/market/saessag/domain/email/service/EmailService.java
@@ -2,8 +2,6 @@ package com.market.saessag.domain.email.service;
 
 import com.market.saessag.domain.user.repository.UserRepository;
 import com.market.saessag.global.exception.*;
-import com.market.saessag.global.response.ApiResponse;
-import com.market.saessag.global.response.SuccessCode;
 import com.market.saessag.global.util.EmailVerification;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -25,11 +23,14 @@ public class EmailService {
     private final UserRepository userRepository;
     private final Map<String, EmailVerification> verificationStore = new ConcurrentHashMap<>(); // 이메일 인증 정보를 저장하는 동시성 지원 Map (Key: 이메일, Value: 인증정보)
 
-    // 이메일 인증 요청
-    public ApiResponse<String> sendVerificationEmail(String toEmail) {
+    /*
+        sendVerificationEmail(): 이메일 인증 코드를 생성하고 발송하는 메서드
+    */
+    public void sendVerificationEmail(String toEmail) {
         try {
+            // 이메일 중복 확인
             if (userRepository.existsByEmail(toEmail)) {
-                return ApiResponse.error(ErrorCode.DUPLICATE_EMAIL); // 이미 가입된 이메일인 경우
+                throw new CustomException(ErrorCode.DUPLICATE_EMAIL); // 이미 가입된 이메일인 경우
             }
 
             // 6자리 랜덤 인증 코드 생성
@@ -44,45 +45,45 @@ public class EmailService {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
             helper.setTo(toEmail);
             helper.setSubject("[새싹마켓] 회원가입 인증번호 안내");
-            helper.setText(createEmailContent(verificationCode), true);
+            helper.setText(createEmailContent(verificationCode), true); // true는 HTML 형식 사용을 의미
 
             // 이메일 발송
             mailSender.send(message);
 
-            return ApiResponse.success(SuccessCode.EMAIL_VERIFICATION_SENT); // 인증 메일 발송
-
-        } catch (MessagingException e) {
-            verificationStore.remove(toEmail); // 이메일 발송 실패 시 저장된 인증 정보 제거
-            return ApiResponse.error(ErrorCode.EMAIL_SEND_FAILED); // 이메일 발송에 실패한 경우
+        } catch (MessagingException e) { // 이메일 발송 실패 시 저장된 인증 정보 제거
+            verificationStore.remove(toEmail);
+            throw new CustomException(ErrorCode.EMAIL_SEND_FAILED); // 이메일 발송 실패
         }
     }
 
-    // 인증 코드 확인
-    public ApiResponse<String> verifyCode(String email, String code) {
+    /*
+        verifyCode(): 인증 코드를 검증하는 메서드
+    */
+    public void verifyCode(String email, String code) { // (이메일 주소, 사용자가 입력한 인증 코드)
         // 저장된 인증 정보 조회
         EmailVerification verification = verificationStore.get(email);
         if (verification == null) {
-            return ApiResponse.error(ErrorCode.INVALID_VERIFICATION_CODE); // 잘못된 인증 코드이거나 인증 정보가 없는 경우
+            throw new CustomException(ErrorCode.INVALID_VERIFICATION_CODE); // 잘못된 인증 코드이거나 인증 정보가 없는 경우
         }
 
         // 만료 여부 확인
         if (verification.isExpired()) {
             verificationStore.remove(email);
-            return ApiResponse.error(ErrorCode.VERIFICATION_EXPIRED); // 인증 코드가 만료된 경우
+            throw new CustomException(ErrorCode.VERIFICATION_EXPIRED); // 인증 코드가 만료된 경우
         }
 
         // 인증 코드 일치 여부 확인
         if (!verification.getCode().equals(code)) {
-            return ApiResponse.error(ErrorCode.INVALID_VERIFICATION_CODE); // 잘못된 인증 코드이거나 인증 정보가 없는 경우
+            throw new CustomException(ErrorCode.INVALID_VERIFICATION_CODE); // 잘못된 인증 코드이거나 인증 정보가 없는 경우
         }
 
         // 인증 완료 처리
         verification.verify();
-
-        return ApiResponse.success(SuccessCode.EMAIL_VERIFICATION_SUCCESS); // 이메일 인증 완료
     }
 
-    // 이메일 인증 완료 여부 확인
+    /*
+        isEmailVerified(): 이메일 인증 완료 여부를 확인하는 메서드
+    */
     public boolean isEmailVerified(String email) {
         EmailVerification verification = verificationStore.get(email);
         if (verification == null) {
@@ -91,12 +92,16 @@ public class EmailService {
         return verification.isVerified(); // 인증 완료 여부
     }
 
-    // 6자리 랜덤 인증 코드를 생성
+    /*
+        generateVerificationCode(): 6자리 랜덤 인증 코드를 생성하는 메서드
+    */
     private String generateVerificationCode() {
         return String.format("%06d", new Random().nextInt(1000000));
     }
 
-    // 이메일 본문 HTML을 생성
+    /*
+        createEmailContent(): 이메일 본문 HTML을 생성하는 메서드
+    */
     private String createEmailContent(String code) {
         return String.format("""
             <div style='text-align: center; margin: 30px;'>
@@ -109,10 +114,12 @@ public class EmailService {
             </div>
             """, code);
     }
-
-    // 만료된 인증 정보를 정리하는 스케줄링 메서드
+    /*
+        cleanupExpiredCodes(): 만료된 인증 정보를 정리하는 스케줄링 메서드
+    */
     @Scheduled(fixedRate = 300000) // 5분(300000ms)마다 자동 실행
     public void cleanupExpiredCodes() {
         verificationStore.entrySet().removeIf(entry -> entry.getValue().isExpired());
     }
+
 }

--- a/src/main/java/com/market/saessag/domain/email/service/EmailService.java
+++ b/src/main/java/com/market/saessag/domain/email/service/EmailService.java
@@ -2,6 +2,8 @@ package com.market.saessag.domain.email.service;
 
 import com.market.saessag.domain.user.repository.UserRepository;
 import com.market.saessag.global.exception.*;
+import com.market.saessag.global.response.ApiResponse;
+import com.market.saessag.global.response.SuccessCode;
 import com.market.saessag.global.util.EmailVerification;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -23,14 +25,11 @@ public class EmailService {
     private final UserRepository userRepository;
     private final Map<String, EmailVerification> verificationStore = new ConcurrentHashMap<>(); // 이메일 인증 정보를 저장하는 동시성 지원 Map (Key: 이메일, Value: 인증정보)
 
-    /*
-        sendVerificationEmail(): 이메일 인증 코드를 생성하고 발송하는 메서드
-    */
-    public void sendVerificationEmail(String toEmail) {
+    // 이메일 인증 요청
+    public ApiResponse<String> sendVerificationEmail(String toEmail) {
         try {
-            // 이메일 중복 확인
             if (userRepository.existsByEmail(toEmail)) {
-                throw new CustomException(ErrorCode.DUPLICATE_EMAIL); // 이미 가입된 이메일인 경우
+                return ApiResponse.error(ErrorCode.DUPLICATE_EMAIL); // 이미 가입된 이메일인 경우
             }
 
             // 6자리 랜덤 인증 코드 생성
@@ -45,45 +44,45 @@ public class EmailService {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
             helper.setTo(toEmail);
             helper.setSubject("[새싹마켓] 회원가입 인증번호 안내");
-            helper.setText(createEmailContent(verificationCode), true); // true는 HTML 형식 사용을 의미
+            helper.setText(createEmailContent(verificationCode), true);
 
             // 이메일 발송
             mailSender.send(message);
 
-        } catch (MessagingException e) { // 이메일 발송 실패 시 저장된 인증 정보 제거
-            verificationStore.remove(toEmail);
-            throw new CustomException(ErrorCode.EMAIL_SEND_FAILED); // 이메일 발송 실패
+            return ApiResponse.success(SuccessCode.EMAIL_VERIFICATION_SENT); // 인증 메일 발송
+
+        } catch (MessagingException e) {
+            verificationStore.remove(toEmail); // 이메일 발송 실패 시 저장된 인증 정보 제거
+            return ApiResponse.error(ErrorCode.EMAIL_SEND_FAILED); // 이메일 발송에 실패한 경우
         }
     }
 
-    /*
-        verifyCode(): 인증 코드를 검증하는 메서드
-    */
-    public void verifyCode(String email, String code) { // (이메일 주소, 사용자가 입력한 인증 코드)
+    // 인증 코드 확인
+    public ApiResponse<String> verifyCode(String email, String code) {
         // 저장된 인증 정보 조회
         EmailVerification verification = verificationStore.get(email);
         if (verification == null) {
-            throw new CustomException(ErrorCode.INVALID_VERIFICATION_CODE); // 잘못된 인증 코드이거나 인증 정보가 없는 경우
+            return ApiResponse.error(ErrorCode.INVALID_VERIFICATION_CODE); // 잘못된 인증 코드이거나 인증 정보가 없는 경우
         }
 
         // 만료 여부 확인
         if (verification.isExpired()) {
             verificationStore.remove(email);
-            throw new CustomException(ErrorCode.VERIFICATION_EXPIRED); // 인증 코드가 만료된 경우
+            return ApiResponse.error(ErrorCode.VERIFICATION_EXPIRED); // 인증 코드가 만료된 경우
         }
 
         // 인증 코드 일치 여부 확인
         if (!verification.getCode().equals(code)) {
-            throw new CustomException(ErrorCode.INVALID_VERIFICATION_CODE); // 잘못된 인증 코드이거나 인증 정보가 없는 경우
+            return ApiResponse.error(ErrorCode.INVALID_VERIFICATION_CODE); // 잘못된 인증 코드이거나 인증 정보가 없는 경우
         }
 
         // 인증 완료 처리
         verification.verify();
+
+        return ApiResponse.success(SuccessCode.EMAIL_VERIFICATION_SUCCESS); // 이메일 인증 완료
     }
 
-    /*
-        isEmailVerified(): 이메일 인증 완료 여부를 확인하는 메서드
-    */
+    // 이메일 인증 완료 여부 확인
     public boolean isEmailVerified(String email) {
         EmailVerification verification = verificationStore.get(email);
         if (verification == null) {
@@ -92,16 +91,12 @@ public class EmailService {
         return verification.isVerified(); // 인증 완료 여부
     }
 
-    /*
-        generateVerificationCode(): 6자리 랜덤 인증 코드를 생성하는 메서드
-    */
+    // 6자리 랜덤 인증 코드를 생성
     private String generateVerificationCode() {
         return String.format("%06d", new Random().nextInt(1000000));
     }
 
-    /*
-        createEmailContent(): 이메일 본문 HTML을 생성하는 메서드
-    */
+    // 이메일 본문 HTML을 생성
     private String createEmailContent(String code) {
         return String.format("""
             <div style='text-align: center; margin: 30px;'>
@@ -114,12 +109,10 @@ public class EmailService {
             </div>
             """, code);
     }
-    /*
-        cleanupExpiredCodes(): 만료된 인증 정보를 정리하는 스케줄링 메서드
-    */
+
+    // 만료된 인증 정보를 정리하는 스케줄링 메서드
     @Scheduled(fixedRate = 300000) // 5분(300000ms)마다 자동 실행
     public void cleanupExpiredCodes() {
         verificationStore.entrySet().removeIf(entry -> entry.getValue().isExpired());
     }
-
 }

--- a/src/main/java/com/market/saessag/domain/email/service/EmailService.java
+++ b/src/main/java/com/market/saessag/domain/email/service/EmailService.java
@@ -23,9 +23,7 @@ public class EmailService {
     private final UserRepository userRepository;
     private final Map<String, EmailVerification> verificationStore = new ConcurrentHashMap<>(); // 이메일 인증 정보를 저장하는 동시성 지원 Map (Key: 이메일, Value: 인증정보)
 
-    /*
-        sendVerificationEmail(): 이메일 인증 코드를 생성하고 발송하는 메서드
-    */
+    // 이메일 인증 요청
     public void sendVerificationEmail(String toEmail) {
         try {
             // 이메일 중복 확인
@@ -56,9 +54,7 @@ public class EmailService {
         }
     }
 
-    /*
-        verifyCode(): 인증 코드를 검증하는 메서드
-    */
+    // 인증 코드 확인
     public void verifyCode(String email, String code) { // (이메일 주소, 사용자가 입력한 인증 코드)
         // 저장된 인증 정보 조회
         EmailVerification verification = verificationStore.get(email);
@@ -81,9 +77,7 @@ public class EmailService {
         verification.verify();
     }
 
-    /*
-        isEmailVerified(): 이메일 인증 완료 여부를 확인하는 메서드
-    */
+    // 이메일 인증 완료 여부 확인
     public boolean isEmailVerified(String email) {
         EmailVerification verification = verificationStore.get(email);
         if (verification == null) {
@@ -92,16 +86,12 @@ public class EmailService {
         return verification.isVerified(); // 인증 완료 여부
     }
 
-    /*
-        generateVerificationCode(): 6자리 랜덤 인증 코드를 생성하는 메서드
-    */
+    // 6자리 랜덤 인증 코드를 생성
     private String generateVerificationCode() {
         return String.format("%06d", new Random().nextInt(1000000));
     }
 
-    /*
-        createEmailContent(): 이메일 본문 HTML을 생성하는 메서드
-    */
+    // 이메일 본문 HTML을 생성
     private String createEmailContent(String code) {
         return String.format("""
             <div style='text-align: center; margin: 30px;'>
@@ -114,12 +104,9 @@ public class EmailService {
             </div>
             """, code);
     }
-    /*
-        cleanupExpiredCodes(): 만료된 인증 정보를 정리하는 스케줄링 메서드
-    */
+    // 만료된 인증 정보를 정리하는 스케줄링 메서드
     @Scheduled(fixedRate = 300000) // 5분(300000ms)마다 자동 실행
     public void cleanupExpiredCodes() {
         verificationStore.entrySet().removeIf(entry -> entry.getValue().isExpired());
     }
-
 }

--- a/src/main/java/com/market/saessag/domain/email/service/PasswordService.java
+++ b/src/main/java/com/market/saessag/domain/email/service/PasswordService.java
@@ -29,7 +29,6 @@ public class PasswordService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final Map<String, TemporaryPassword> temporaryPasswordStore = new ConcurrentHashMap<>(); // 임시 저장소 추가
 
-    
     // 임시 비밀번호 발급
     public void sendTemporaryPassword(String email) {
         try {
@@ -125,5 +124,4 @@ public class PasswordService {
         user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
         userRepository.save(user);
     }
-
 }

--- a/src/main/java/com/market/saessag/domain/email/service/PasswordService.java
+++ b/src/main/java/com/market/saessag/domain/email/service/PasswordService.java
@@ -5,6 +5,8 @@ import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
 import com.market.saessag.global.exception.CustomException;
 import com.market.saessag.global.exception.ErrorCode;
+import com.market.saessag.global.response.ApiResponse;
+import com.market.saessag.global.response.SuccessCode;
 import com.market.saessag.global.util.TemporaryPassword;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -29,9 +31,8 @@ public class PasswordService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final Map<String, TemporaryPassword> temporaryPasswordStore = new ConcurrentHashMap<>(); // 임시 저장소 추가
 
-    
     // 임시 비밀번호 발급
-    public void sendTemporaryPassword(String email) {
+    public ApiResponse<String> sendTemporaryPassword(String email) {
         try {
             // 1. 사용자 존재 여부 확인
             User user = userRepository.findByEmail(email)
@@ -52,9 +53,10 @@ public class PasswordService {
             user.updatePassword(passwordEncoder.encode(temporaryPassword));
             userRepository.save(user);
 
+            return ApiResponse.success(SuccessCode.TEMP_PASSWORD_SENT);
         } catch (CustomException e) {
             temporaryPasswordStore.remove(email);
-            throw new CustomException(ErrorCode.EMAIL_SEND_FAILED);
+            return ApiResponse.error(ErrorCode.TEMP_PASSWORD_SEND_FAILED);
         }
     }
 
@@ -73,7 +75,8 @@ public class PasswordService {
         return password.toString();
     }
 
-    private void sendPasswordEmail(String email, String temporaryPassword) {
+    // 임시 비밀번호 발송
+    private ApiResponse<String> sendPasswordEmail(String email, String temporaryPassword) {
         try {
             // 이메일 메시지 생성
             MimeMessage message = mailSender.createMimeMessage();
@@ -85,23 +88,25 @@ public class PasswordService {
 
             // 이메일 발송
             mailSender.send(message);
-        } catch (MessagingException e) {// 이메일 발송 실패 시 임시 저장소에서 제거
-            temporaryPasswordStore.remove(email);
-            throw new CustomException(ErrorCode.EMAIL_SEND_FAILED); // 이메일 발송 실패
+            return ApiResponse.success(SuccessCode.TEMP_PASSWORD_EMAIL_SENT);
+
+        } catch (MessagingException e) {
+            temporaryPasswordStore.remove(email); // 이메일 발송 실패 시 임시 저장소에서 제거
+            return ApiResponse.error(ErrorCode.EMAIL_SEND_FAILED); // 이메일 발송 실패
         }
     }
 
     private String createEmailContent(String temporaryPassword) {
         return String.format("""
-            <div style='text-align: center; margin: 30px;'>
-                <h3> saessagMarket </h3>
-                <h2>임시 비밀번호 발급</h2>
-                <p> 본 메일은 saessagMarket 임시 비밀번호 발급을 위한 이메일입니다.</p>
-                <p>아래의 임시 비밀번호로 로그인해 주세요.</p>
-                <p>보안을 위해 로그인 후 비밀번호를 변경해 주세요.</p>
-                <p style='font-size: 24px; font-weight: bold; margin: 20px;'>%s</p>
-            </div>
-            """, temporaryPassword);
+                <div style='text-align: center; margin: 30px;'>
+                    <h3> saessagMarket </h3>
+                    <h2>임시 비밀번호 발급</h2>
+                    <p> 본 메일은 saessagMarket 임시 비밀번호 발급을 위한 이메일입니다.</p>
+                    <p>아래의 임시 비밀번호로 로그인해 주세요.</p>
+                    <p>보안을 위해 로그인 후 비밀번호를 변경해 주세요.</p>
+                    <p style='font-size: 24px; font-weight: bold; margin: 20px;'>%s</p>
+                </div>
+                """, temporaryPassword);
     }
 
     // 5분마다 만료된 임시 비밀번호 정리
@@ -109,21 +114,26 @@ public class PasswordService {
     public void cleanupExpiredPasswords() {
         temporaryPasswordStore.entrySet().removeIf(entry -> entry.getValue().isExpired());
     }
-    
+
     // 비밀번호 변경
     @Transactional
-    public void changePassword(PasswordChangeRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    public ApiResponse<String> changePassword(PasswordChangeRequest request) {
+        try {
+            User user = userRepository.findByEmail(request.getEmail())
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 현재 비밀번호 확인
-        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
-            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+            // 현재 비밀번호 확인
+            if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+                throw new CustomException(ErrorCode.INVALID_PASSWORD);
+            }
+
+            // 새 비밀번호 암호화 및 업데이트
+            user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
+            userRepository.save(user);
+
+            return ApiResponse.success(SuccessCode.PASSWORD_CHANGED);
+        } catch (Exception e) {
+            return ApiResponse.error(ErrorCode.PASSWORD_CHANGE_FAILED);
         }
-
-        // 새 비밀번호 암호화 및 업데이트
-        user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
-        userRepository.save(user);
     }
-
 }

--- a/src/main/java/com/market/saessag/domain/email/service/PasswordService.java
+++ b/src/main/java/com/market/saessag/domain/email/service/PasswordService.java
@@ -5,8 +5,6 @@ import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
 import com.market.saessag.global.exception.CustomException;
 import com.market.saessag.global.exception.ErrorCode;
-import com.market.saessag.global.response.ApiResponse;
-import com.market.saessag.global.response.SuccessCode;
 import com.market.saessag.global.util.TemporaryPassword;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -31,8 +29,9 @@ public class PasswordService {
     private final BCryptPasswordEncoder passwordEncoder;
     private final Map<String, TemporaryPassword> temporaryPasswordStore = new ConcurrentHashMap<>(); // 임시 저장소 추가
 
+    
     // 임시 비밀번호 발급
-    public ApiResponse<String> sendTemporaryPassword(String email) {
+    public void sendTemporaryPassword(String email) {
         try {
             // 1. 사용자 존재 여부 확인
             User user = userRepository.findByEmail(email)
@@ -53,10 +52,9 @@ public class PasswordService {
             user.updatePassword(passwordEncoder.encode(temporaryPassword));
             userRepository.save(user);
 
-            return ApiResponse.success(SuccessCode.TEMP_PASSWORD_SENT);
         } catch (CustomException e) {
             temporaryPasswordStore.remove(email);
-            return ApiResponse.error(ErrorCode.TEMP_PASSWORD_SEND_FAILED);
+            throw new CustomException(ErrorCode.EMAIL_SEND_FAILED);
         }
     }
 
@@ -75,8 +73,7 @@ public class PasswordService {
         return password.toString();
     }
 
-    // 임시 비밀번호 발송
-    private ApiResponse<String> sendPasswordEmail(String email, String temporaryPassword) {
+    private void sendPasswordEmail(String email, String temporaryPassword) {
         try {
             // 이메일 메시지 생성
             MimeMessage message = mailSender.createMimeMessage();
@@ -88,25 +85,23 @@ public class PasswordService {
 
             // 이메일 발송
             mailSender.send(message);
-            return ApiResponse.success(SuccessCode.TEMP_PASSWORD_EMAIL_SENT);
-
-        } catch (MessagingException e) {
-            temporaryPasswordStore.remove(email); // 이메일 발송 실패 시 임시 저장소에서 제거
-            return ApiResponse.error(ErrorCode.EMAIL_SEND_FAILED); // 이메일 발송 실패
+        } catch (MessagingException e) {// 이메일 발송 실패 시 임시 저장소에서 제거
+            temporaryPasswordStore.remove(email);
+            throw new CustomException(ErrorCode.EMAIL_SEND_FAILED); // 이메일 발송 실패
         }
     }
 
     private String createEmailContent(String temporaryPassword) {
         return String.format("""
-                <div style='text-align: center; margin: 30px;'>
-                    <h3> saessagMarket </h3>
-                    <h2>임시 비밀번호 발급</h2>
-                    <p> 본 메일은 saessagMarket 임시 비밀번호 발급을 위한 이메일입니다.</p>
-                    <p>아래의 임시 비밀번호로 로그인해 주세요.</p>
-                    <p>보안을 위해 로그인 후 비밀번호를 변경해 주세요.</p>
-                    <p style='font-size: 24px; font-weight: bold; margin: 20px;'>%s</p>
-                </div>
-                """, temporaryPassword);
+            <div style='text-align: center; margin: 30px;'>
+                <h3> saessagMarket </h3>
+                <h2>임시 비밀번호 발급</h2>
+                <p> 본 메일은 saessagMarket 임시 비밀번호 발급을 위한 이메일입니다.</p>
+                <p>아래의 임시 비밀번호로 로그인해 주세요.</p>
+                <p>보안을 위해 로그인 후 비밀번호를 변경해 주세요.</p>
+                <p style='font-size: 24px; font-weight: bold; margin: 20px;'>%s</p>
+            </div>
+            """, temporaryPassword);
     }
 
     // 5분마다 만료된 임시 비밀번호 정리
@@ -114,26 +109,21 @@ public class PasswordService {
     public void cleanupExpiredPasswords() {
         temporaryPasswordStore.entrySet().removeIf(entry -> entry.getValue().isExpired());
     }
-
+    
     // 비밀번호 변경
     @Transactional
-    public ApiResponse<String> changePassword(PasswordChangeRequest request) {
-        try {
-            User user = userRepository.findByEmail(request.getEmail())
-                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    public void changePassword(PasswordChangeRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-            // 현재 비밀번호 확인
-            if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
-                throw new CustomException(ErrorCode.INVALID_PASSWORD);
-            }
-
-            // 새 비밀번호 암호화 및 업데이트
-            user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
-            userRepository.save(user);
-
-            return ApiResponse.success(SuccessCode.PASSWORD_CHANGED);
-        } catch (Exception e) {
-            return ApiResponse.error(ErrorCode.PASSWORD_CHANGE_FAILED);
+        // 현재 비밀번호 확인
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
+
+        // 새 비밀번호 암호화 및 업데이트
+        user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
+        userRepository.save(user);
     }
+
 }

--- a/src/main/java/com/market/saessag/domain/user/controller/SignInController.java
+++ b/src/main/java/com/market/saessag/domain/user/controller/SignInController.java
@@ -2,23 +2,21 @@ package com.market.saessag.domain.user.controller;
 
 import com.market.saessag.domain.user.dto.SignInRequest;
 import com.market.saessag.domain.user.dto.SignInResponse;
-import com.market.saessag.domain.user.entity.User;
-import com.market.saessag.domain.user.repository.UserRepository;
 import com.market.saessag.domain.user.service.SignInService;
 import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,31 +24,26 @@ import org.springframework.web.bind.annotation.*;
 public class SignInController {
 
     private final SignInService signInService;
-    private final UserRepository userRepository;
 
     @PostMapping("/sign-in")
-    public ResponseEntity<ApiResponse<SignInResponse>> signIn(
+    public ApiResponse<SignInResponse> signIn(
             @Validated @RequestBody SignInRequest signInRequest,
             HttpServletRequest request) {
 
-        // 기존 로그인 로직 수행
-        SignInResponse userProfileResponse = signInService.signIn(signInRequest);
+        // 로그인 서비스 호출
+        SignInResponse signInResponse = signInService.signIn(signInRequest);
 
-        // 사용자 조회
-        User user = userRepository.findByEmail(signInRequest.getEmail())
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
-
-        // 로그인 성공 시 SecurityContext에 인증 정보가 저장됨
+        // SecurityContext 설정
         SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
         Authentication authentication = new UsernamePasswordAuthenticationToken(
-                user,
+                signInResponse.getEmail(),
                 null,
-                user.getAuthorities() // User 엔티티에 getAuthorities() 메서드 필요
+                Collections.emptyList()
         );
         securityContext.setAuthentication(authentication);
         SecurityContextHolder.setContext(securityContext);
 
-        // 세션에 SecurityContext와 사용자 정보 저장
+        // 세션 설정
         HttpSession session = request.getSession(true);
         session.setAttribute(
                 HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
@@ -58,9 +51,9 @@ public class SignInController {
         );
 
         // 기존 세션 데이터 설정
-        session.setAttribute("userProfile", userProfileResponse);
-        session.setAttribute("email", user.getEmail());
+        session.setAttribute("userProfile", signInResponse);
+        session.setAttribute("email", signInResponse.getEmail());
 
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, userProfileResponse));
+        return ApiResponse.success(SuccessCode.SIGNIN_SUCCESS, signInResponse);
     }
 }

--- a/src/main/java/com/market/saessag/domain/user/controller/SignUpController.java
+++ b/src/main/java/com/market/saessag/domain/user/controller/SignUpController.java
@@ -5,8 +5,9 @@ import com.market.saessag.domain.email.dto.EmailVerificationRequest;
 import com.market.saessag.domain.email.service.EmailService;
 import com.market.saessag.domain.user.service.SignUpService;
 import com.market.saessag.domain.user.dto.SignUpRequest;
+import com.market.saessag.global.response.ApiResponse;
+import com.market.saessag.global.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,25 +24,22 @@ public class SignUpController {
 
     // 이메일 중복 확인 및 인증 코드 발송
     @PostMapping("/email/verify")
-    public ResponseEntity<?> verifyEmail(@RequestBody @Validated EmailRequest emailRequest) {
-        // 이메일 중복 확인 후 인증 코드 발송
+    public ApiResponse<String> verifyEmail(@RequestBody @Validated EmailRequest emailRequest) {
         emailService.sendVerificationEmail(emailRequest.getEmail());
-        return ResponseEntity.ok("인증 메일이 발송되었습니다."); // 응답 포맷 통일 필요함
+        return ApiResponse.success(SuccessCode.EMAIL_VERIFICATION_SENT);
     }
 
     // 인증 코드 확인
     @PostMapping("/email/confirm")
-    public ResponseEntity<?> confirmEmail(@RequestBody @Validated EmailVerificationRequest request) {
+    public ApiResponse<String> confirmEmail(@RequestBody @Validated EmailVerificationRequest request) {
         emailService.verifyCode(request.getEmail(), request.getCode());
-        return ResponseEntity.ok("이메일 인증이 완료되었습니다."); // 응답 포맷 통일 필요함
+        return ApiResponse.success(SuccessCode.EMAIL_VERIFIED);
     }
 
-    // 회원가입
+    // 회원가입 (이메일 인증 여부 확인 후 진행)
     @PostMapping
-    public ResponseEntity<?> signUp(@RequestBody @Validated SignUpRequest signUpRequest) {
-        // 이메일 인증 여부 확인 후 회원가입 진행
+    public ApiResponse<String> signUp(@RequestBody @Validated SignUpRequest signUpRequest) {
         signUpService.signUp(signUpRequest);
-        return ResponseEntity.ok("회원가입이 완료되었습니다."); // 응답 포맷 통일 필요함
+        return ApiResponse.success(SuccessCode.SIGNUP_COMPLETED);
     }
-
 }

--- a/src/main/java/com/market/saessag/domain/user/controller/SignUpController.java
+++ b/src/main/java/com/market/saessag/domain/user/controller/SignUpController.java
@@ -5,8 +5,8 @@ import com.market.saessag.domain.email.dto.EmailVerificationRequest;
 import com.market.saessag.domain.email.service.EmailService;
 import com.market.saessag.domain.user.service.SignUpService;
 import com.market.saessag.domain.user.dto.SignUpRequest;
+import com.market.saessag.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,25 +23,19 @@ public class SignUpController {
 
     // 이메일 중복 확인 및 인증 코드 발송
     @PostMapping("/email/verify")
-    public ResponseEntity<?> verifyEmail(@RequestBody @Validated EmailRequest emailRequest) {
-        // 이메일 중복 확인 후 인증 코드 발송
-        emailService.sendVerificationEmail(emailRequest.getEmail());
-        return ResponseEntity.ok("인증 메일이 발송되었습니다."); // 응답 포맷 통일 필요함
+    public ApiResponse<String> verifyEmail(@RequestBody @Validated EmailRequest emailRequest) {
+        return emailService.sendVerificationEmail(emailRequest.getEmail());
     }
 
     // 인증 코드 확인
     @PostMapping("/email/confirm")
-    public ResponseEntity<?> confirmEmail(@RequestBody @Validated EmailVerificationRequest request) {
-        emailService.verifyCode(request.getEmail(), request.getCode());
-        return ResponseEntity.ok("이메일 인증이 완료되었습니다."); // 응답 포맷 통일 필요함
+    public ApiResponse<String> confirmEmail(@RequestBody @Validated EmailVerificationRequest request) {
+        return emailService.verifyCode(request.getEmail(), request.getCode());
     }
 
-    // 회원가입
+    // 회원가입 (이메일 인증 여부 확인 후 진행)
     @PostMapping
-    public ResponseEntity<?> signUp(@RequestBody @Validated SignUpRequest signUpRequest) {
-        // 이메일 인증 여부 확인 후 회원가입 진행
-        signUpService.signUp(signUpRequest);
-        return ResponseEntity.ok("회원가입이 완료되었습니다."); // 응답 포맷 통일 필요함
+    public ApiResponse<String> signUp(@RequestBody @Validated SignUpRequest signUpRequest) {
+        return signUpService.signUp(signUpRequest);
     }
-
 }

--- a/src/main/java/com/market/saessag/domain/user/controller/SignUpController.java
+++ b/src/main/java/com/market/saessag/domain/user/controller/SignUpController.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/sign-up")
 public class SignUpController {
 
     private final SignUpService signUpService;
     private final EmailService emailService;
 
     // 이메일 중복 확인 및 인증 코드 발송
-    @PostMapping("/sign-up/email/verify")
+    @PostMapping("/email/verify")
     public ResponseEntity<?> verifyEmail(@RequestBody @Validated EmailRequest emailRequest) {
         // 이메일 중복 확인 후 인증 코드 발송
         emailService.sendVerificationEmail(emailRequest.getEmail());
@@ -30,14 +30,14 @@ public class SignUpController {
     }
 
     // 인증 코드 확인
-    @PostMapping("/sign-up/email/confirm")
+    @PostMapping("/email/confirm")
     public ResponseEntity<?> confirmEmail(@RequestBody @Validated EmailVerificationRequest request) {
         emailService.verifyCode(request.getEmail(), request.getCode());
         return ResponseEntity.ok("이메일 인증이 완료되었습니다."); // 응답 포맷 통일 필요함
     }
 
     // 회원가입
-    @PostMapping("/sign-up")
+    @PostMapping
     public ResponseEntity<?> signUp(@RequestBody @Validated SignUpRequest signUpRequest) {
         // 이메일 인증 여부 확인 후 회원가입 진행
         signUpService.signUp(signUpRequest);

--- a/src/main/java/com/market/saessag/domain/user/controller/SignUpController.java
+++ b/src/main/java/com/market/saessag/domain/user/controller/SignUpController.java
@@ -5,8 +5,8 @@ import com.market.saessag.domain.email.dto.EmailVerificationRequest;
 import com.market.saessag.domain.email.service.EmailService;
 import com.market.saessag.domain.user.service.SignUpService;
 import com.market.saessag.domain.user.dto.SignUpRequest;
-import com.market.saessag.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,19 +23,25 @@ public class SignUpController {
 
     // 이메일 중복 확인 및 인증 코드 발송
     @PostMapping("/email/verify")
-    public ApiResponse<String> verifyEmail(@RequestBody @Validated EmailRequest emailRequest) {
-        return emailService.sendVerificationEmail(emailRequest.getEmail());
+    public ResponseEntity<?> verifyEmail(@RequestBody @Validated EmailRequest emailRequest) {
+        // 이메일 중복 확인 후 인증 코드 발송
+        emailService.sendVerificationEmail(emailRequest.getEmail());
+        return ResponseEntity.ok("인증 메일이 발송되었습니다."); // 응답 포맷 통일 필요함
     }
 
     // 인증 코드 확인
     @PostMapping("/email/confirm")
-    public ApiResponse<String> confirmEmail(@RequestBody @Validated EmailVerificationRequest request) {
-        return emailService.verifyCode(request.getEmail(), request.getCode());
+    public ResponseEntity<?> confirmEmail(@RequestBody @Validated EmailVerificationRequest request) {
+        emailService.verifyCode(request.getEmail(), request.getCode());
+        return ResponseEntity.ok("이메일 인증이 완료되었습니다."); // 응답 포맷 통일 필요함
     }
 
-    // 회원가입 (이메일 인증 여부 확인 후 진행)
+    // 회원가입
     @PostMapping
-    public ApiResponse<String> signUp(@RequestBody @Validated SignUpRequest signUpRequest) {
-        return signUpService.signUp(signUpRequest);
+    public ResponseEntity<?> signUp(@RequestBody @Validated SignUpRequest signUpRequest) {
+        // 이메일 인증 여부 확인 후 회원가입 진행
+        signUpService.signUp(signUpRequest);
+        return ResponseEntity.ok("회원가입이 완료되었습니다."); // 응답 포맷 통일 필요함
     }
+
 }

--- a/src/main/java/com/market/saessag/domain/user/service/SignInService.java
+++ b/src/main/java/com/market/saessag/domain/user/service/SignInService.java
@@ -4,12 +4,12 @@ import com.market.saessag.domain.user.dto.SignInRequest;
 import com.market.saessag.domain.user.dto.SignInResponse;
 import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
+import com.market.saessag.global.exception.CustomException;
+import com.market.saessag.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,10 +20,14 @@ public class SignInService {
 
     @Transactional
     public SignInResponse signIn(SignInRequest signInRequest) {
-        Optional<User> userOptional = userRepository.findByEmail(signInRequest.getEmail());
-        User user = userOptional.get();
-        validateUserExists(signInRequest.getEmail()); // 이메일 검증
-        validatePassword(signInRequest.getPassword(), user.getPassword()); // 비밀번호 검증
+        // 사용자 조회
+        User user = userRepository.findByEmail(signInRequest.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(signInRequest.getPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
 
         return SignInResponse.builder()
                 .id(user.getId())
@@ -32,17 +36,4 @@ public class SignInService {
                 .nickname(user.getNickname())
                 .build();
     }
-
-    private void validateUserExists(String email) {
-        if (!userRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("존재하지 않는 이메일입니다.");
-        }
-    }
-
-    private void validatePassword(String rawPassword, String encodedPassword) {
-        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
-    }
-
 }

--- a/src/main/java/com/market/saessag/domain/user/service/SignUpService.java
+++ b/src/main/java/com/market/saessag/domain/user/service/SignUpService.java
@@ -1,12 +1,12 @@
-// 회원가입 처리
 package com.market.saessag.domain.user.service;
 
 import com.market.saessag.domain.email.service.EmailService;
 import com.market.saessag.domain.user.dto.SignUpRequest;
 import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
-import com.market.saessag.global.exception.CustomException;
 import com.market.saessag.global.exception.ErrorCode;
+import com.market.saessag.global.response.ApiResponse;
+import com.market.saessag.global.response.SuccessCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -20,29 +20,35 @@ public class SignUpService {
     private final EmailService emailService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
+    // 회원가입
     @Transactional
-    public void signUp(SignUpRequest signUpRequest) {
+    public ApiResponse<String> signUp(SignUpRequest signUpRequest) {
         String email = signUpRequest.getEmail();
 
         // 1. 이메일 인증 여부 먼저 확인
         if (!emailService.isEmailVerified(email)) {
-            throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED); // 이메일 미인증 시
+            return ApiResponse.error(ErrorCode.EMAIL_NOT_VERIFIED);
         }
 
         // 2. 이메일 중복 확인
         if (userRepository.existsByEmail(email)) {
-            throw new CustomException(ErrorCode.DUPLICATE_EMAIL); // 중복 이메일
+            return ApiResponse.error(ErrorCode.DUPLICATE_EMAIL);
         }
 
         // 3. 회원가입 진행
-        User user = User.builder()
-                .email(email)
-                .password(bCryptPasswordEncoder.encode(signUpRequest.getPassword()))
-                .nickname(signUpRequest.getNickname())
-                .role("ROLE_USER")
-                .build();
+        try {
+            User user = User.builder()
+                    .email(email)
+                    .password(bCryptPasswordEncoder.encode(signUpRequest.getPassword()))
+                    .nickname(signUpRequest.getNickname())
+                    .role("ROLE_USER")
+                    .build();
 
-        userRepository.save(user);
+            userRepository.save(user);
+
+            return ApiResponse.success(SuccessCode.SIGNUP_SUCCESS);
+        } catch (Exception e) {
+            return ApiResponse.error(ErrorCode.SIGNUP_FAILED);
+        }
     }
-
 }

--- a/src/main/java/com/market/saessag/domain/user/service/SignUpService.java
+++ b/src/main/java/com/market/saessag/domain/user/service/SignUpService.java
@@ -1,12 +1,12 @@
+// 회원가입 처리
 package com.market.saessag.domain.user.service;
 
 import com.market.saessag.domain.email.service.EmailService;
 import com.market.saessag.domain.user.dto.SignUpRequest;
 import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
+import com.market.saessag.global.exception.CustomException;
 import com.market.saessag.global.exception.ErrorCode;
-import com.market.saessag.global.response.ApiResponse;
-import com.market.saessag.global.response.SuccessCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -20,35 +20,29 @@ public class SignUpService {
     private final EmailService emailService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    // 회원가입
     @Transactional
-    public ApiResponse<String> signUp(SignUpRequest signUpRequest) {
+    public void signUp(SignUpRequest signUpRequest) {
         String email = signUpRequest.getEmail();
 
         // 1. 이메일 인증 여부 먼저 확인
         if (!emailService.isEmailVerified(email)) {
-            return ApiResponse.error(ErrorCode.EMAIL_NOT_VERIFIED);
+            throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED); // 이메일 미인증 시
         }
 
         // 2. 이메일 중복 확인
         if (userRepository.existsByEmail(email)) {
-            return ApiResponse.error(ErrorCode.DUPLICATE_EMAIL);
+            throw new CustomException(ErrorCode.DUPLICATE_EMAIL); // 중복 이메일
         }
 
         // 3. 회원가입 진행
-        try {
-            User user = User.builder()
-                    .email(email)
-                    .password(bCryptPasswordEncoder.encode(signUpRequest.getPassword()))
-                    .nickname(signUpRequest.getNickname())
-                    .role("ROLE_USER")
-                    .build();
+        User user = User.builder()
+                .email(email)
+                .password(bCryptPasswordEncoder.encode(signUpRequest.getPassword()))
+                .nickname(signUpRequest.getNickname())
+                .role("ROLE_USER")
+                .build();
 
-            userRepository.save(user);
-
-            return ApiResponse.success(SuccessCode.SIGNUP_SUCCESS);
-        } catch (Exception e) {
-            return ApiResponse.error(ErrorCode.SIGNUP_FAILED);
-        }
+        userRepository.save(user);
     }
+
 }

--- a/src/main/java/com/market/saessag/domain/user/service/SignUpService.java
+++ b/src/main/java/com/market/saessag/domain/user/service/SignUpService.java
@@ -1,4 +1,3 @@
-// 회원가입 처리
 package com.market.saessag.domain.user.service;
 
 import com.market.saessag.domain.email.service.EmailService;
@@ -20,6 +19,7 @@ public class SignUpService {
     private final EmailService emailService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
+    // 회원가입
     @Transactional
     public void signUp(SignUpRequest signUpRequest) {
         String email = signUpRequest.getEmail();
@@ -44,5 +44,4 @@ public class SignUpService {
 
         userRepository.save(user);
     }
-
 }

--- a/src/main/java/com/market/saessag/global/config/PathConst.java
+++ b/src/main/java/com/market/saessag/global/config/PathConst.java
@@ -4,20 +4,20 @@ package com.market.saessag.global.config;
 public class PathConst {
     // 인증(로그인)이 필요없는 경로들
     public static final String[] EXCLUDED_PATHS = {
-            "/api/sign-up",                    // 회원가입
+            "/api/sign-up/**",                 // 회원가입 관련
             "/api/sign-in",                    // 로그인
             "/api/products/list",              // 상품 목록 조회
+            "/api/password/find",              // 비밀번호 발급
             "/error"                           // 에러 페이지
     };
 
     // 인증(로그인)이 필요한 경로들
     public static final String[] AUTHENTICATED_PATHS = {
             "/api/products",                    // 상품 등록
-            "/api/products/**",                 // 상품 수정, 삭제, 상세 조회, 상품 끌어올리기
-                                                // 상품 좋아요, 상품 상태 값 변경
-
-            "/api/profile/upload-image",        // 프로필 사진 업로드
-            "/api/profile"                      // 프로필 사진 조회
+            "/api/products/**",                 // 상품 수정, 삭제 등
+            "/api/photos/**",                   // 사진 관련
+            "/api/profile/**",                  // 프로필 사진 관련
+            "/api/password/change"              // 비밀번호 변경
     };
 
     private PathConst() {} // 인스턴스화 방지

--- a/src/main/java/com/market/saessag/global/exception/ErrorCode.java
+++ b/src/main/java/com/market/saessag/global/exception/ErrorCode.java
@@ -22,7 +22,11 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 요청 값입니다"),
     RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS,"너무 많은 요청이 발생했습니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    SIGNUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "회원가입 처리 중 오류가 발생했습니다."),
+    SIGNIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "로그인 처리 중 오류가 발생했습니다."),
+    TEMP_PASSWORD_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "임시 비밀번호 발송에 실패했습니다."),
+    PASSWORD_CHANGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "비밀번호 변경에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/market/saessag/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/market/saessag/global/exception/GlobalExceptionHandler.java
@@ -25,9 +25,8 @@ public class GlobalExceptionHandler {
 
     // 3. 공통된 예외 처리
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
-        ApiResponse<Void> response = ApiResponse.error(e.getErrorCode());
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(response);
+    public ApiResponse<String> handleCustomException(CustomException e) {
+        return ApiResponse.error(e.getErrorCode());
     }
 
     // 4. 기타 서버 예외 처리

--- a/src/main/java/com/market/saessag/global/response/ApiResponse.java
+++ b/src/main/java/com/market/saessag/global/response/ApiResponse.java
@@ -12,12 +12,21 @@ public class ApiResponse<T> {
     private final String message; // 응답 메시지
     private final T data;        // 실제 데이터
 
-    // 성공 응답 생성
+    // 성공 응답 생성 (조회 등 데이터를 포함한 응답)
     public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
         return ApiResponse.<T>builder()
                 .status(successCode.getHttpStatus())
                 .message(successCode.getMessage())
                 .data(data)
+                .build();
+    }
+
+    // 성공 응답 생성
+    public static <T> ApiResponse<T> success(SuccessCode successCode) {
+        return ApiResponse.<T>builder()
+                .status(successCode.getHttpStatus())
+                .message(successCode.getMessage())
+                .data(null)
                 .build();
     }
 

--- a/src/main/java/com/market/saessag/global/response/SuccessCode.java
+++ b/src/main/java/com/market/saessag/global/response/SuccessCode.java
@@ -15,7 +15,17 @@ public enum SuccessCode {
     NO_CONTENT(HttpStatus.NO_CONTENT, "리소스가 성공적으로 삭제되었습니다."),
     PRODUCT_UPDATED(HttpStatus.OK, "상품이 성공적으로 수정되었습니다."),
     LIKE_ADDED(HttpStatus.OK, "좋아요가 추가되었습니다."),
-    LIKE_REMOVED(HttpStatus.OK, "좋아요가 취소되었습니다.");
+    LIKE_REMOVED(HttpStatus.OK, "좋아요가 취소되었습니다."),
+    EMAIL_VERIFICATION_SENT(HttpStatus.OK, "인증 메일이 발송되었습니다."),
+    EMAIL_VERIFICATION_SUCCESS(HttpStatus.OK, "이메일 인증이 완료되었습니다."),
+    SIGNUP_SUCCESS(HttpStatus.OK, "회원가입이 완료되었습니다."),
+    SIGNIN_SUCCESS(HttpStatus.OK, "로그인이 성공적으로 완료되었습니다."),
+    TEMP_PASSWORD_SENT(HttpStatus.OK, "임시 비밀번호가 이메일로 발송되었습니다."),
+    PASSWORD_CHANGED(HttpStatus.OK, "비밀번호가 성공적으로 변경되었습니다."),
+    TEMP_PASSWORD_EMAIL_SENT(HttpStatus.OK, "임시 비밀번호가 이메일로 발송되었습니다."),
+    VALIDATION_SUCCESS(HttpStatus.OK, "검증이 성공적으로 완료되었습니다."),
+    EMAIL_VERIFIED(HttpStatus.OK, "이메일 인증이 완료되었습니다"),
+    SIGNUP_COMPLETED(HttpStatus.CREATED, "회원가입이 완료되었습니다");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## #️⃣ Issue Number

#74

## 📝 작업 설명

유저 관련 세션 PathConst를 설정합니다.

ApiResponse를 이용한 일관된 응답 처리를 활용합니다.

응답 형식을 ResponseEntity -> ApiResponse로 통일했습니다.

ApiResponse의 성공 응답을 데이터 포함/미포함 2개의 형식으로 나누었습니다.
![image](https://github.com/user-attachments/assets/09347a17-c393-4dde-ae18-b60492671e5a)


이렇게 되면 조회 등 GET 메서드를 활용하여 데이터 반환이 필요할 경우, 위의 메서드를 사용하면 될 것 같습니다.
유저 관련해서는 GET 메서드를 사용할 일이 없었는데, 상품 관련해서는 사용할 일이 좀 있겠네요!

## 📸스크린샷 (선택)   

## 💬 리뷰 요구사항
Service에서도 ApiResponse를 적용해야 하는 줄 알았는데 Controller만 적용하면 되더라구요 ㅋㅋㅋ
이런저런 시도를 하느라 커밋 수가 좀 많아진 것 같네요 🫠

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
