### PR TITLE
사진 관련 세션 인증/인가 처리 및 공통 응답 구현

### DIFF
--- a/src/main/java/com/market/saessag/domain/auth/AuthService.java
+++ b/src/main/java/com/market/saessag/domain/auth/AuthService.java
@@ -1,0 +1,24 @@
+package com.market.saessag.domain.auth;
+
+import com.market.saessag.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.HttpSessionRequiredException;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    // 세션에서 인증된 사용자의 이메일을 조회
+    public String getAuthenticatedEmail(HttpServletRequest request)
+            throws HttpSessionRequiredException {
+        HttpSession session = request.getSession();
+        String email = (String) session.getAttribute("email");
+        if (email == null) {
+            throw new HttpSessionRequiredException(ErrorCode.UNAUTHORIZED.getMessage());
+        }
+        return email;
+    }
+}

--- a/src/main/java/com/market/saessag/domain/photo/controller/PhotoController.java
+++ b/src/main/java/com/market/saessag/domain/photo/controller/PhotoController.java
@@ -1,9 +1,12 @@
 package com.market.saessag.domain.photo.controller;
 
+import com.market.saessag.domain.auth.AuthService;
 import com.market.saessag.domain.photo.service.S3Service;
 import com.market.saessag.global.exception.ErrorCode;
 import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.HttpSessionRequiredException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,21 +18,27 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/photos")
 public class PhotoController {
+    private final AuthService authService;
     private final S3Service s3Service;
 
-    public PhotoController(S3Service s3Service) {
+    public PhotoController(AuthService authService, S3Service s3Service) {
+        this.authService = authService;
         this.s3Service = s3Service;
     }
 
     @PostMapping("/upload")
-    public ApiResponse<List<String>> uploadPhotos(@RequestParam MultipartFile[] files) {
-        List<String> fileUrls = new ArrayList<>();
+    public ApiResponse<List<String>> uploadPhotos(@RequestParam MultipartFile[] files, HttpServletRequest request) {
         try {
+            authService.getAuthenticatedEmail(request); // 로그인 한 사용자만 사진 업로드 가능
+
+            List<String> fileUrls = new ArrayList<>();
             for (MultipartFile file : files) {
                 String fileUrl = s3Service.uploadFile(file);
                 fileUrls.add(fileUrl);
             }
             return ApiResponse.success(SuccessCode.OK, fileUrls);
+        } catch (HttpSessionRequiredException e) {
+            return ApiResponse.error(ErrorCode.UNAUTHORIZED);
         } catch (IOException e) {
             return ApiResponse.error(ErrorCode.FILE_UPLOAD_ERROR);
         }

--- a/src/main/java/com/market/saessag/domain/photo/controller/ProfileImageController.java
+++ b/src/main/java/com/market/saessag/domain/photo/controller/ProfileImageController.java
@@ -1,11 +1,13 @@
 package com.market.saessag.domain.photo.controller;
 
+import com.market.saessag.domain.auth.AuthService;
 import com.market.saessag.domain.photo.service.S3Service;
 import com.market.saessag.global.exception.ErrorCode;
 import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.HttpSessionRequiredException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,38 +18,32 @@ import java.util.Map;
 @RequestMapping("/api/profile")
 @RequiredArgsConstructor
 public class ProfileImageController {
+    private final AuthService authService;
     private final S3Service s3Service;
 
-    /*
-         프로필 사진 업로드
-         사용자 관점에서는 프로필 사진 업로드와 수정이 동일한 방식으로 진행됨.
-         따라서 하나의 Patch 메서드에서 동작함.
-     */
-    @PatchMapping("/upload-image")
-    public ApiResponse<String> uploadProfileImage(@RequestParam("file") MultipartFile file, HttpSession session) {
+    // 프로필 사진 업로드
+    @PatchMapping("/upload-image") // 사용자 관점에서는 프로필 사진 업로드와 수정이 동일한 방식으로 진행됨. 따라서 하나의 Patch 메서드에서 동작함.
+    public ApiResponse<String> uploadProfileImage(@RequestParam("file") MultipartFile file, HttpServletRequest request) {
         try {
-            String email = (String) session.getAttribute("email");
-            if (email == null) {
-                return ApiResponse.error(ErrorCode.UNAUTHORIZED);
-            }
-
+            String email = authService.getAuthenticatedEmail(request);
             String fileUrl = s3Service.uploadProfileImage(file, email);
             return ApiResponse.success(SuccessCode.UPLOAD_SUCCESS, fileUrl);
+        } catch (HttpSessionRequiredException e) {
+            return ApiResponse.error(ErrorCode.UNAUTHORIZED);
         } catch (IOException e) {
             return ApiResponse.error(ErrorCode.FILE_UPLOAD_ERROR);
         }
     }
 
-    // 프로필 사진 조회
+    // 프로필 사진 조회(현재 본인 프로필 사진만 확인 가능)
     @GetMapping
-    public ApiResponse<Map<String, String>> getProfileImageUrl(HttpSession session) {
-        String email = (String) session.getAttribute("email");
-        if (email == null) {
+    public ApiResponse<Map<String, String>> getProfileImageUrl(HttpServletRequest request) {
+        try {
+            String email = authService.getAuthenticatedEmail(request);
+            Map<String, String> urls = s3Service.getProfileImageUrl(email);
+            return ApiResponse.success(SuccessCode.OK, urls);
+        } catch (HttpSessionRequiredException e) {
             return ApiResponse.error(ErrorCode.UNAUTHORIZED);
         }
-
-        Map<String, String> urls = s3Service.getProfileImageUrl(email);
-        return ApiResponse.success(SuccessCode.OK, urls);
     }
-
 }

--- a/src/main/java/com/market/saessag/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/market/saessag/global/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.market.saessag.global.exception;
 
 import com.market.saessag.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpSessionRequiredException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -11,9 +13,9 @@ public class GlobalExceptionHandler {
 
     // 1. 세션 관련 예외를 먼저 처리
     @ExceptionHandler(HttpSessionRequiredException.class)
-    public ResponseEntity<ApiResponse<Void>> handleSessionException(HttpSessionRequiredException e) {
-        ApiResponse<Void> response = ApiResponse.error(ErrorCode.UNAUTHORIZED);
-        return ResponseEntity.status(ErrorCode.UNAUTHORIZED.getHttpStatus()).body(response);
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ApiResponse<Void> handleSessionException(HttpSessionRequiredException e) {
+        return ApiResponse.error(ErrorCode.UNAUTHORIZED);
     }
 
     // 2. IllegalArgumentException 처리


### PR DESCRIPTION
## #️⃣ Issue Number

#75 

## 📝 작업 설명

사진 관련 세션 인증/인가 처리 및 공통 응답 리팩토링을 했습니다.
- HttpSession session -> HttpServletRequest request 변경
- ApiResponse 응답 통일
- 세션 인증 로직을 AuthService로 분리하여 코드 중복 제거

## 📸스크린샷 (선택)   

## 💬 리뷰 요구사항

사진 관련 코드는 다음과 같이 동작합니다!
1. 로그인 후 세션 획득
2. /api/photos/upload로 사진 업로드
3. 받은 URL을 ProductRequest의 photo 리스트에 담아서 상품 생성 API 호출(직접 request 값 넣어주는 방식)
4. 조회 시 /api/photos?keys=이미지키로 presigned URL 획득


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
