### PR TITLE
채팅 기능 세션 이용 및 응답 타입 통일

### DIFF
--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
@@ -21,12 +21,12 @@ public class ChatMessageController {
     @GetMapping("/{roomId}")
     public ApiResponse<List<ChatMessageResponse>> getMessages(
             @PathVariable Long roomId,
-            @RequestParam Long userId,
+            HttpServletRequest request,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
-        List<ChatMessageResponse> messages = chatMessageService.getMessages(roomId, userId, page, size);
-        return ApiResponse.success(SuccessCode.OK, messages);
+        List<ChatMessageResponse> messages = chatMessageService.getMessages(roomId, request, page, size);
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, messages);
     }
 
     // 채팅방 내 메시지 검색

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
@@ -4,6 +4,7 @@ import com.market.saessag.domain.chat.dto.ChatMessageResponse;
 import com.market.saessag.domain.chat.service.ChatMessageService;
 import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,22 +39,22 @@ public class ChatMessageController {
 
     // 읽음 처리
     @PostMapping("/{roomId}/mark-read")
-    public ResponseEntity<ApiResponse<Void>> markMessageAsRead(@PathVariable Long roomId, @RequestParam Long userId) { //user 세션으로 바꿀 것
-        chatMessageService.markMessagesAsRead(roomId, userId);
+    public ResponseEntity<ApiResponse<Void>> markMessageAsRead(@PathVariable Long roomId, HttpServletRequest request) { //user 세션으로 바꿀 것
+        chatMessageService.markMessagesAsRead(roomId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, null));
     }
 
     // 안 읽은 메시지 목록 조회
     @GetMapping("/{roomId}/unread-list")
-    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getUnreadMessages(@PathVariable Long roomId, @RequestParam Long userId) {
-        List<ChatMessageResponse> unreadMessages = chatMessageService.getUnreadMessages(roomId, userId);
+    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getUnreadMessages(@PathVariable Long roomId, HttpServletRequest request) {
+        List<ChatMessageResponse> unreadMessages = chatMessageService.getUnreadMessages(roomId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, unreadMessages));
     }
 
     // 안 읽은 메시지 개수 조회
     @GetMapping("/{roomId}/unread-count")
-    public ResponseEntity<ApiResponse<Long>> unreadMessageCount(@PathVariable Long roomId, @RequestParam Long userId) {
-        Long unreadCount = chatMessageService.getUnreadMessageCount(roomId, userId);
+    public ResponseEntity<ApiResponse<Long>> unreadMessageCount(@PathVariable Long roomId, HttpServletRequest request) {
+        Long unreadCount = chatMessageService.getUnreadMessageCount(roomId, request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, unreadCount));
     }
 

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
@@ -6,7 +6,6 @@ import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -34,28 +33,28 @@ public class ChatMessageController {
     public ApiResponse<List<ChatMessageResponse>> searchMessages(
             @PathVariable Long roomId,
             @RequestParam String keyword) {
-        return ApiResponse.success(SuccessCode.OK, chatMessageService.searchMessages(roomId, keyword));
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, chatMessageService.searchMessages(roomId, keyword));
     }
 
     // 읽음 처리
     @PostMapping("/{roomId}/mark-read")
     public ApiResponse<Void> markMessageAsRead(@PathVariable Long roomId, HttpServletRequest request) { //user 세션으로 바꿀 것
         chatMessageService.markMessagesAsRead(roomId, request);
-        return ApiResponse.success(SuccessCode.OK, null);
+        return ApiResponse.success(SuccessCode.OK);
     }
 
     // 안 읽은 메시지 목록 조회
     @GetMapping("/{roomId}/unread-list")
     public ApiResponse<List<ChatMessageResponse>> getUnreadMessages(@PathVariable Long roomId, HttpServletRequest request) {
         List<ChatMessageResponse> unreadMessages = chatMessageService.getUnreadMessages(roomId, request);
-        return ApiResponse.success(SuccessCode.OK, unreadMessages);
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, unreadMessages);
     }
 
     // 안 읽은 메시지 개수 조회
     @GetMapping("/{roomId}/unread-count")
     public ApiResponse<Long> unreadMessageCount(@PathVariable Long roomId, HttpServletRequest request) {
         Long unreadCount = chatMessageService.getUnreadMessageCount(roomId, request);
-        return ApiResponse.success(SuccessCode.OK, unreadCount);
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, unreadCount);
     }
 
 

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
@@ -19,43 +19,43 @@ public class ChatMessageController {
 
     // 채팅방 전체 메시지 반환
     @GetMapping("/{roomId}")
-    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessages(
+    public ApiResponse<List<ChatMessageResponse>> getMessages(
             @PathVariable Long roomId,
             @RequestParam Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
         List<ChatMessageResponse> messages = chatMessageService.getMessages(roomId, userId, page, size);
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, messages));
+        return ApiResponse.success(SuccessCode.OK, messages);
     }
 
     // 채팅방 내 메시지 검색
     @GetMapping("/{roomId}/search")
-    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> searchMessages(
+    public ApiResponse<List<ChatMessageResponse>> searchMessages(
             @PathVariable Long roomId,
             @RequestParam String keyword) {
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, chatMessageService.searchMessages(roomId, keyword)));
+        return ApiResponse.success(SuccessCode.OK, chatMessageService.searchMessages(roomId, keyword));
     }
 
     // 읽음 처리
     @PostMapping("/{roomId}/mark-read")
-    public ResponseEntity<ApiResponse<Void>> markMessageAsRead(@PathVariable Long roomId, HttpServletRequest request) { //user 세션으로 바꿀 것
+    public ApiResponse<Void> markMessageAsRead(@PathVariable Long roomId, HttpServletRequest request) { //user 세션으로 바꿀 것
         chatMessageService.markMessagesAsRead(roomId, request);
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, null));
+        return ApiResponse.success(SuccessCode.OK, null);
     }
 
     // 안 읽은 메시지 목록 조회
     @GetMapping("/{roomId}/unread-list")
-    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getUnreadMessages(@PathVariable Long roomId, HttpServletRequest request) {
+    public ApiResponse<List<ChatMessageResponse>> getUnreadMessages(@PathVariable Long roomId, HttpServletRequest request) {
         List<ChatMessageResponse> unreadMessages = chatMessageService.getUnreadMessages(roomId, request);
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, unreadMessages));
+        return ApiResponse.success(SuccessCode.OK, unreadMessages);
     }
 
     // 안 읽은 메시지 개수 조회
     @GetMapping("/{roomId}/unread-count")
-    public ResponseEntity<ApiResponse<Long>> unreadMessageCount(@PathVariable Long roomId, HttpServletRequest request) {
+    public ApiResponse<Long> unreadMessageCount(@PathVariable Long roomId, HttpServletRequest request) {
         Long unreadCount = chatMessageService.getUnreadMessageCount(roomId, request);
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, unreadCount));
+        return ApiResponse.success(SuccessCode.OK, unreadCount);
     }
 
 

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageWebSocketController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageWebSocketController.java
@@ -29,20 +29,20 @@ public class ChatMessageWebSocketController {
     // 메시지 전송
     @MessageMapping("/chat/{roomId}/sendMessage")
     @SendTo("/topic/chat/{roomId}")
-    public ResponseEntity<ApiResponse<ChatMessageResponse>> sendMessage(@DestinationVariable Long roomId, @Payload ChatMessageRequest message) {
+    public ApiResponse<ChatMessageResponse> sendMessage(@DestinationVariable Long roomId, @Payload ChatMessageRequest message) {
         ChatMessageResponse savedMessage = chatMessageService.saveMessage(roomId, message);
 
         //오프라인 구독자들에게 메시지 전송
         chatSubscriptionService.sendToOffSubscriber(savedMessage, roomId);
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, savedMessage));
+        return ApiResponse.success(SuccessCode.OK, savedMessage);
     }
 
     // 파일 전송
     @MessageMapping("/chat/{roomId}/sendFile")
     @SendTo("/topic/chat/{roomId}")
-    public ResponseEntity<ApiResponse<List<ChatFileResponse>>> sendFile(@DestinationVariable Long roomId, @Payload ChatFileRequest fileRequest) {
+    public ApiResponse<List<ChatFileResponse>> sendFile(@DestinationVariable Long roomId, @Payload ChatFileRequest fileRequest) {
         List<ChatFileResponse> savedFile = chatFileService.saveFile(roomId, fileRequest);
 
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, savedFile));
+        return ApiResponse.success(SuccessCode.OK, savedFile);
     }
 }

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatRoomController.java
@@ -20,18 +20,18 @@ public class ChatRoomController {
 
     // 방 생성
     @PostMapping()
-    public ResponseEntity<ApiResponse<ChatRoomResponse>> createChatRoom(@RequestBody ChatRoomRequest request) {
+    public ApiResponse<ChatRoomResponse> createChatRoom(@RequestBody ChatRoomRequest request) {
         ChatRoomResponse chatRoom = chatRoomService.createOrGetChatRoom(request.getProductId(), request.getBuyerId(), request.getSellerId());
 
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, chatRoom));
+        return ApiResponse.success(SuccessCode.OK, chatRoom);
     }
 
     // 특정 유저가 속해있는 채팅방 리스트 반환
     @GetMapping("/{userId}")
-    public ResponseEntity<ApiResponse<List<ChatRoomResponse>>> getChatRoom(@PathVariable Long userId) {
+    public ApiResponse<List<ChatRoomResponse>> getChatRoom(@PathVariable Long userId) {
         List<ChatRoomResponse> chatRooms = chatRoomService.getUserChatRooms(userId);
 
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, chatRooms));
+        return ApiResponse.success(SuccessCode.OK, chatRooms);
     }
 
 }

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatRoomController.java
@@ -23,7 +23,7 @@ public class ChatRoomController {
     public ApiResponse<ChatRoomResponse> createChatRoom(@RequestBody ChatRoomRequest request) {
         ChatRoomResponse chatRoom = chatRoomService.createOrGetChatRoom(request.getProductId(), request.getBuyerId(), request.getSellerId());
 
-        return ApiResponse.success(SuccessCode.OK, chatRoom);
+        return ApiResponse.success(SuccessCode.ROOM_CREATED, chatRoom);
     }
 
     // 특정 유저가 속해있는 채팅방 리스트 반환
@@ -31,7 +31,7 @@ public class ChatRoomController {
     public ApiResponse<List<ChatRoomResponse>> getChatRoom(@PathVariable Long userId) {
         List<ChatRoomResponse> chatRooms = chatRoomService.getUserChatRooms(userId);
 
-        return ApiResponse.success(SuccessCode.OK, chatRooms);
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, chatRooms);
     }
 
 }

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatFileService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatFileService.java
@@ -11,6 +11,8 @@ import com.market.saessag.domain.chat.repository.ChatRoomRepository;
 import com.market.saessag.domain.photo.service.S3Service;
 import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
+import com.market.saessag.global.exception.CustomException;
+import com.market.saessag.global.exception.ErrorCode;
 import com.market.saessag.util.FileTypeUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,10 +34,10 @@ public class ChatFileService {
 
     public List<ChatFileResponse> saveFile(Long roomId, ChatFileRequest fileRequest) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 방이 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         User sender = userRepository.findById(fileRequest.getSenderId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         ChatMessage chatMessage = ChatMessage.builder()
                 .chatRoom(chatRoom)

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
@@ -53,12 +53,11 @@ public class ChatMessageService {
         return ChatMessageResponse.fromEntity(savedMessage, false);
     }
 
-    public List<ChatMessageResponse> getMessages(Long roomId, Long userId, int page, int size) {
+    public List<ChatMessageResponse> getMessages(Long roomId, HttpServletRequest httpRequest, int page, int size) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
 
-        User sender = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+        Long userId = getUserFromSession(httpRequest).getId();
 
         Long receiverId = chatRoom.getBuyer().getId().equals(userId) ? chatRoom.getSeller().getId() : chatRoom.getBuyer().getId();
 

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
@@ -36,10 +36,10 @@ public class ChatMessageService {
 
     public ChatMessageResponse saveMessage(Long roomId, ChatMessageRequest message) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 방이 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         User sender = userRepository.findById(message.getSenderId()) //세션으로 변경
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         ChatMessage newMessage = ChatMessage.builder()
                 .chatRoom(chatRoom)
@@ -55,7 +55,7 @@ public class ChatMessageService {
 
     public List<ChatMessageResponse> getMessages(Long roomId, HttpServletRequest httpRequest, int page, int size) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         Long userId = getUserFromSession(httpRequest).getId();
 
@@ -77,7 +77,7 @@ public class ChatMessageService {
     // 메시지 검색
     public List<ChatMessageResponse> searchMessages(Long roomId, String keyword){
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 방이 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         List<ChatMessage> messages = chatMessageRepository.findByChatRoomAndContentContainingOrderByTimeStampDesc(chatRoom, keyword);
 
@@ -90,7 +90,7 @@ public class ChatMessageService {
     @Transactional
     public void markMessagesAsRead(Long roomId, HttpServletRequest httpRequest) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         User user = getUserFromSession(httpRequest);
 
@@ -113,7 +113,7 @@ public class ChatMessageService {
     @Transactional
     public Long getUnreadMessageCount(Long roomId, HttpServletRequest httpRequest) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         User user = getUserFromSession(httpRequest);
 
@@ -128,7 +128,7 @@ public class ChatMessageService {
     // 안 읽은 메시지 조회
     public List<ChatMessageResponse> getUnreadMessages(Long roomId, HttpServletRequest httpRequest) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         User user = getUserFromSession(httpRequest);
 
@@ -157,6 +157,6 @@ public class ChatMessageService {
         }
 
         return userRepository.findById(userSession.getId())
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
@@ -8,8 +8,13 @@ import com.market.saessag.domain.chat.entity.ChatRoom;
 import com.market.saessag.domain.chat.repository.ChatMessageReadRepository;
 import com.market.saessag.domain.chat.repository.ChatMessageRepository;
 import com.market.saessag.domain.chat.repository.ChatRoomRepository;
+import com.market.saessag.domain.user.dto.SignInResponse;
 import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
+import com.market.saessag.global.exception.CustomException;
+import com.market.saessag.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -84,12 +89,11 @@ public class ChatMessageService {
 
     // 읽음 처리
     @Transactional
-    public void markMessagesAsRead(Long roomId, Long userId) {
+    public void markMessagesAsRead(Long roomId, HttpServletRequest httpRequest) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+        User user = getUserFromSession(httpRequest);
 
         List<ChatMessage> unreadMessages = chatMessageRepository.findByChatRoom(chatRoom);
 
@@ -108,12 +112,11 @@ public class ChatMessageService {
 
     // 안 읽은 메시지 수 카운트
     @Transactional
-    public Long getUnreadMessageCount(Long roomId, Long userId) {
+    public Long getUnreadMessageCount(Long roomId, HttpServletRequest httpRequest) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+        User user = getUserFromSession(httpRequest);
 
         List<Long> readMessageIds = chatMessageReadRepository.findMessageIdByUserAndChatRoom(user, chatRoom);
         if (readMessageIds.isEmpty()) {
@@ -124,12 +127,11 @@ public class ChatMessageService {
     }
 
     // 안 읽은 메시지 조회
-    public List<ChatMessageResponse> getUnreadMessages(Long roomId, Long userId) {
+    public List<ChatMessageResponse> getUnreadMessages(Long roomId, HttpServletRequest httpRequest) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채팅방이 없습니다."));
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
+        User user = getUserFromSession(httpRequest);
 
         // 읽은 메시지 테이블에서 특정 채팅방에서 해당 유저가 읽은 메시지의 ID 리스트를 반환
         List<Long> readMessageIds = chatMessageReadRepository.findMessageIdByUserAndChatRoom(user, chatRoom);
@@ -144,5 +146,18 @@ public class ChatMessageService {
         return unreadMessages.stream()
                 .map(message -> ChatMessageResponse.fromEntity(message, false))
                 .collect(Collectors.toList());
+    }
+
+    // 세션에서 사용자 정보를 가져와서 검증
+    private User getUserFromSession(HttpServletRequest request) {
+        HttpSession session = request.getSession();
+        SignInResponse userSession = (SignInResponse) session.getAttribute("userProfile");
+
+        if (userSession == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        return userRepository.findById(userSession.getId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatRoomService.java
@@ -11,6 +11,8 @@ import com.market.saessag.domain.product.entity.Product;
 import com.market.saessag.domain.product.repository.ProductRepository;
 import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
+import com.market.saessag.global.exception.CustomException;
+import com.market.saessag.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -29,7 +31,7 @@ public class ChatRoomService {
     //방 생성 (방 존재 시 채팅방 반환)
     public ChatRoomResponse createOrGetChatRoom(Long productId, Long buyerId, Long sellerId) {
         Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
         User buyer = userRepository.findById(buyerId)
                 .orElseThrow(() -> new IllegalArgumentException("구매자를 찾을 수 없습니다."));
@@ -57,7 +59,7 @@ public class ChatRoomService {
     // 유저의 모든 채팅방 반환
     public List<ChatRoomResponse> getUserChatRooms(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저가 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         List<ChatRoom> chatRooms = chatRoomRepository.findByBuyerOrSeller(user, user);
 

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatSubscriptionService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatSubscriptionService.java
@@ -5,6 +5,8 @@ import com.market.saessag.domain.chat.entity.ChatRoom;
 import com.market.saessag.domain.chat.entity.ChatSubscription;
 import com.market.saessag.domain.chat.repository.ChatRoomRepository;
 import com.market.saessag.domain.chat.repository.ChatSubscriptionRepository;
+import com.market.saessag.global.exception.CustomException;
+import com.market.saessag.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
@@ -23,7 +25,7 @@ public class ChatSubscriptionService {
     public void sendToOffSubscriber(ChatMessageResponse savedMessage, Long roomId) {
         // DB에서 해당 채팅방을 구독한 사용자 목록 조회
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 방이 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
         List<ChatSubscription> subscriptions = chatSubscriptionRepository.findByChatRoom(chatRoom);
 
         for (ChatSubscription subscription : subscriptions) {

--- a/src/main/java/com/market/saessag/global/exception/ErrorCode.java
+++ b/src/main/java/com/market/saessag/global/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
     SIGNUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "회원가입 처리 중 오류가 발생했습니다."),
     SIGNIN_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "로그인 처리 중 오류가 발생했습니다."),
     TEMP_PASSWORD_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "임시 비밀번호 발송에 실패했습니다."),
-    PASSWORD_CHANGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "비밀번호 변경에 실패했습니다.");
+    PASSWORD_CHANGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "비밀번호 변경에 실패했습니다."),
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 방입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/market/saessag/global/response/SuccessCode.java
+++ b/src/main/java/com/market/saessag/global/response/SuccessCode.java
@@ -25,7 +25,9 @@ public enum SuccessCode {
     TEMP_PASSWORD_EMAIL_SENT(HttpStatus.OK, "임시 비밀번호가 이메일로 발송되었습니다."),
     VALIDATION_SUCCESS(HttpStatus.OK, "검증이 성공적으로 완료되었습니다."),
     EMAIL_VERIFIED(HttpStatus.OK, "이메일 인증이 완료되었습니다"),
-    SIGNUP_COMPLETED(HttpStatus.CREATED, "회원가입이 완료되었습니다");
+    SIGNUP_COMPLETED(HttpStatus.CREATED, "회원가입이 완료되었습니다"),
+    ROOM_CREATED(HttpStatus.OK,"방이 성공적으로 생성되었습니다."),
+    DATA_FETCHED(HttpStatus.OK, "데이터 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## #️⃣ Issue Number

#85 

## 📝 작업 설명

- 유저 ID를 쿼리 파라미터로 받아 처리하고 있던 부분을 세션을 통해 유저 정보를 받아 처리하도록 변경했습니다.
- 응답 반환 타입이 통일이 되어있지 않아 ApiResponse로 통일하도록 수정했습니다.

## 📸스크린샷 (선택)   

## 💬 리뷰 요구사항

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
