### PR TITLE
WebSocket 세션 처리

### DIFF
--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageController.java
@@ -2,9 +2,11 @@ package com.market.saessag.domain.chat.controller;
 
 import com.market.saessag.domain.chat.dto.ChatMessageResponse;
 import com.market.saessag.domain.chat.service.ChatMessageService;
+import com.market.saessag.domain.user.dto.SignInResponse;
 import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,8 +41,12 @@ public class ChatMessageController {
 
     // 읽음 처리
     @PostMapping("/{roomId}/mark-read")
-    public ApiResponse<Void> markMessageAsRead(@PathVariable Long roomId, HttpServletRequest request) { //user 세션으로 바꿀 것
-        chatMessageService.markMessagesAsRead(roomId, request);
+    public ApiResponse<Void> markMessageAsRead(@PathVariable Long roomId, HttpServletRequest request) {
+        // 변경된 세션 처리 통합한 후 수정하겠습니다!
+        HttpSession session = request.getSession();
+        SignInResponse userSession = (SignInResponse) session.getAttribute("userProfile");
+
+        chatMessageService.markMessagesAsRead(roomId, userSession);
         return ApiResponse.success();
     }
 

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageWebSocketController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageWebSocketController.java
@@ -7,6 +7,7 @@ import com.market.saessag.domain.chat.dto.ChatMessageResponse;
 import com.market.saessag.domain.chat.service.ChatFileService;
 import com.market.saessag.domain.chat.service.ChatMessageService;
 import com.market.saessag.domain.chat.service.ChatSubscriptionService;
+import com.market.saessag.domain.user.dto.SignInResponse;
 import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,9 @@ public class ChatMessageWebSocketController {
 
         ChatMessageResponse savedMessage = chatMessageService.saveMessage(roomId, message, headerAccessor);
 
-        // 현재 임시로 메시지 보낸 후 메시지 읽음 API 사용하여 자신의 메시지 읽음 처리하도록 하는 중
+        //메시지 읽음 처리
+        SignInResponse user = (SignInResponse) headerAccessor.getSessionAttributes().get("userProfile");
+        chatMessageService.markMessagesAsRead(roomId, user);
 
         //오프라인 구독자들에게 메시지 전송
         chatSubscriptionService.sendToOffSubscriber(savedMessage, roomId);

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageWebSocketController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatMessageWebSocketController.java
@@ -10,10 +10,8 @@ import com.market.saessag.domain.chat.service.ChatSubscriptionService;
 import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.handler.annotation.*;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
@@ -28,10 +26,11 @@ public class ChatMessageWebSocketController {
     // 메시지 전송
     @MessageMapping("/chat/{roomId}/sendMessage")
     @SendTo("/topic/chat/{roomId}")
-    public ApiResponse<ChatMessageResponse> sendMessage(@DestinationVariable Long roomId, @Payload ChatMessageRequest message) {
-        ChatMessageResponse savedMessage = chatMessageService.saveMessage(roomId, message);
+    public ApiResponse<ChatMessageResponse> sendMessage(@DestinationVariable Long roomId, @Payload ChatMessageRequest message,
+                                                        SimpMessageHeaderAccessor headerAccessor) {
 
-        // 추후에 세션 정보로 읽음 처리 꼭 할 것
+        ChatMessageResponse savedMessage = chatMessageService.saveMessage(roomId, message, headerAccessor);
+
         // 현재 임시로 메시지 보낸 후 메시지 읽음 API 사용하여 자신의 메시지 읽음 처리하도록 하는 중
 
         //오프라인 구독자들에게 메시지 전송

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.market.saessag.domain.chat.controller;
 
+import com.market.saessag.domain.chat.dto.ChatRoomCreateResponse;
 import com.market.saessag.domain.chat.dto.ChatRoomRequest;
 import com.market.saessag.domain.chat.dto.ChatRoomResponse;
 import com.market.saessag.domain.chat.service.ChatRoomService;
@@ -20,10 +21,10 @@ public class ChatRoomController {
 
     // 방 생성
     @PostMapping()
-    public ApiResponse<ChatRoomResponse> createChatRoom(@RequestBody ChatRoomRequest request) {
-        Pair<SuccessCode, ChatRoomResponse> SuccessCodeAndChatRoom = chatRoomService.createOrGetChatRoom(request.getProductId(), request.getBuyerId(), request.getSellerId());
+    public ApiResponse<ChatRoomCreateResponse> createChatRoom(@RequestBody ChatRoomRequest request) {
+        ChatRoomCreateResponse chatRoom = chatRoomService.createOrGetChatRoom(request.getProductId(), request.getBuyerId(), request.getSellerId());
 
-        return ApiResponse.success(SuccessCodeAndChatRoom.getFirst(), SuccessCodeAndChatRoom.getSecond());
+        return ApiResponse.success(chatRoom);
     }
 
     // 특정 유저가 현재 속해있는 채팅방 리스트 반환

--- a/src/main/java/com/market/saessag/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/market/saessag/domain/chat/controller/ChatRoomController.java
@@ -7,6 +7,7 @@ import com.market.saessag.global.response.ApiResponse;
 import com.market.saessag.global.response.SuccessCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,9 +21,9 @@ public class ChatRoomController {
     // 방 생성
     @PostMapping()
     public ApiResponse<ChatRoomResponse> createChatRoom(@RequestBody ChatRoomRequest request) {
-        ChatRoomResponse chatRoom = chatRoomService.createOrGetChatRoom(request.getProductId(), request.getBuyerId(), request.getSellerId());
+        Pair<SuccessCode, ChatRoomResponse> SuccessCodeAndChatRoom = chatRoomService.createOrGetChatRoom(request.getProductId(), request.getBuyerId(), request.getSellerId());
 
-        return ApiResponse.success(SuccessCode.ROOM_CREATED, chatRoom);
+        return ApiResponse.success(SuccessCodeAndChatRoom.getFirst(), SuccessCodeAndChatRoom.getSecond());
     }
 
     // 특정 유저가 현재 속해있는 채팅방 리스트 반환

--- a/src/main/java/com/market/saessag/domain/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/market/saessag/domain/chat/dto/ChatMessageRequest.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class ChatMessageRequest {
-    private Long senderId;
     private String content;
     private LocalDateTime timeStamp;
 }

--- a/src/main/java/com/market/saessag/domain/chat/dto/ChatRoomCreateResponse.java
+++ b/src/main/java/com/market/saessag/domain/chat/dto/ChatRoomCreateResponse.java
@@ -1,0 +1,12 @@
+package com.market.saessag.domain.chat.dto;
+
+import com.market.saessag.global.response.SuccessCode;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatRoomCreateResponse {
+    private SuccessCode successCode;
+    private ChatRoomResponse chatRoomResponse;
+}

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
@@ -19,6 +19,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -35,11 +36,12 @@ public class ChatMessageService {
     private final UserRepository userRepository;
     private final ChatMessageReadRepository chatMessageReadRepository;
 
-    public ChatMessageResponse saveMessage(Long roomId, ChatMessageRequest message) {
+    public ChatMessageResponse saveMessage(Long roomId, ChatMessageRequest message, SimpMessageHeaderAccessor headerAccessor) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
-        User sender = userRepository.findById(message.getSenderId()) //세션으로 변경
+        SignInResponse user = (SignInResponse) headerAccessor.getSessionAttributes().get("userProfile");
+        User sender = userRepository.findById(user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         ChatMessage newMessage = ChatMessage.builder()

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatMessageService.java
@@ -112,11 +112,17 @@ public class ChatMessageService {
 
     // 읽음 처리
     @Transactional
-    public void markMessagesAsRead(Long roomId, HttpServletRequest httpRequest) {
+    public void markMessagesAsRead(Long roomId, SignInResponse userSession) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
-        User user = getUserFromSession(httpRequest);
+
+        if (userSession == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        User user = userRepository.findById(userSession.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         List<ChatMessage> unreadMessages = chatMessageRepository.findByChatRoom(chatRoom);
 

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatRoomService.java
@@ -14,14 +14,17 @@ import com.market.saessag.domain.user.entity.User;
 import com.market.saessag.domain.user.repository.UserRepository;
 import com.market.saessag.global.exception.CustomException;
 import com.market.saessag.global.exception.ErrorCode;
+import com.market.saessag.global.response.SuccessCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,7 +37,7 @@ public class ChatRoomService {
     private final ChatSubscriptionRepository chatSubscriptionRepository;
 
     //방 생성 (방 존재 시 채팅방 반환)
-    public ChatRoomResponse createOrGetChatRoom(Long productId, Long buyerId, Long sellerId) {
+    public Pair<SuccessCode,ChatRoomResponse> createOrGetChatRoom(Long productId, Long buyerId, Long sellerId) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
@@ -44,21 +47,28 @@ public class ChatRoomService {
         User seller = userRepository.findById(sellerId)
                 .orElseThrow(() -> new IllegalArgumentException("판매자를 찾을 수 없습니다."));
 
-        ChatRoom chatRoom = chatRoomRepository.findByProductAndBuyerAndSeller(product, buyer, seller)
-                .orElseGet(() -> {
-                    ChatRoom newRoom = ChatRoom.builder()
-                            .product(product)
-                            .buyer(buyer)
-                            .seller(seller)
-                            .build();
+        Optional<ChatRoom> chatRoom = chatRoomRepository.findByProductAndBuyerAndSeller(product, buyer, seller);
 
-                    return chatRoomRepository.save(newRoom);
-                });
+        // 새로운 채팅방 생성하는 경우
+        if (chatRoom.isEmpty()) {
+            ChatRoom newRoom = ChatRoom.builder()
+                    .product(product)
+                    .buyer(buyer)
+                    .seller(seller)
+                    .build();
 
-        subscribeUserToChatRoom(buyer, chatRoom);
-        subscribeUserToChatRoom(seller, chatRoom);
+            chatRoomRepository.save(newRoom);
 
-        return chatRoomResponseEntity(chatRoom);
+            // 구독 목록에 추가
+            subscribeUserToChatRoom(buyer, newRoom);
+            subscribeUserToChatRoom(seller, newRoom);
+
+            return Pair.of(SuccessCode.ROOM_CREATED, chatRoomResponseEntity(newRoom));
+        }
+
+        // 기존 채팅방 불러오는 경우
+
+        return Pair.of(SuccessCode.DATA_FETCHED, chatRoomResponseEntity(chatRoom.orElse(null)));
     }
 
     // 유저의 모든 채팅방 반환

--- a/src/main/java/com/market/saessag/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/market/saessag/domain/chat/service/ChatRoomService.java
@@ -1,5 +1,6 @@
 package com.market.saessag.domain.chat.service;
 
+import com.market.saessag.domain.chat.dto.ChatRoomCreateResponse;
 import com.market.saessag.domain.chat.dto.ChatRoomResponse;
 import com.market.saessag.domain.chat.entity.ChatMessage;
 import com.market.saessag.domain.chat.entity.ChatRoom;
@@ -37,7 +38,7 @@ public class ChatRoomService {
     private final ChatSubscriptionRepository chatSubscriptionRepository;
 
     //방 생성 (방 존재 시 채팅방 반환)
-    public Pair<SuccessCode,ChatRoomResponse> createOrGetChatRoom(Long productId, Long buyerId, Long sellerId) {
+    public ChatRoomCreateResponse createOrGetChatRoom(Long productId, Long buyerId, Long sellerId) {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PRODUCT_NOT_FOUND));
 
@@ -63,12 +64,18 @@ public class ChatRoomService {
             subscribeUserToChatRoom(buyer, newRoom);
             subscribeUserToChatRoom(seller, newRoom);
 
-            return Pair.of(SuccessCode.ROOM_CREATED, chatRoomResponseEntity(newRoom));
+            return ChatRoomCreateResponse.builder()
+                    .successCode(SuccessCode.ROOM_CREATED)
+                    .chatRoomResponse(chatRoomResponseEntity(newRoom))
+                    .build();
         }
 
         // 기존 채팅방 불러오는 경우
 
-        return Pair.of(SuccessCode.DATA_FETCHED, chatRoomResponseEntity(chatRoom.orElse(null)));
+        return ChatRoomCreateResponse.builder()
+                .successCode(SuccessCode.ROOM_FETCHED)
+                .chatRoomResponse(chatRoomResponseEntity(chatRoom.get()))
+                .build();
     }
 
     // 유저의 모든 채팅방 반환

--- a/src/main/java/com/market/saessag/global/config/WebSocketConfig.java
+++ b/src/main/java/com/market/saessag/global/config/WebSocketConfig.java
@@ -1,10 +1,12 @@
 package com.market.saessag.global.config;
 
+import com.market.saessag.global.interceptor.WebSocketHandShakeInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -13,7 +15,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         //WebSocket 엔드포인트 설정 (ws://localhost:8080/ws)
         registry.addEndpoint("/ws")
-                .setAllowedOrigins("*");
+                .setAllowedOrigins("*")
+                .addInterceptors(new WebSocketHandShakeInterceptor());
     }
 
     @Override

--- a/src/main/java/com/market/saessag/global/interceptor/WebSocketHandShakeInterceptor.java
+++ b/src/main/java/com/market/saessag/global/interceptor/WebSocketHandShakeInterceptor.java
@@ -1,0 +1,33 @@
+package com.market.saessag.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+public class WebSocketHandShakeInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        if (request instanceof ServletServerHttpRequest) {
+            ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+            HttpSession session = servletRequest.getServletRequest().getSession(false);
+
+            if (session != null) {
+                // 세션 정보 유저 정보에서 가져와 WebSocket 세션에 저장
+                attributes.put("userProfile", session.getAttribute("userProfile"));
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}

--- a/src/main/java/com/market/saessag/global/response/SuccessCode.java
+++ b/src/main/java/com/market/saessag/global/response/SuccessCode.java
@@ -27,6 +27,7 @@ public enum SuccessCode {
     EMAIL_VERIFIED(HttpStatus.OK, "이메일 인증이 완료되었습니다"),
     SIGNUP_COMPLETED(HttpStatus.CREATED, "회원가입이 완료되었습니다"),
     ROOM_CREATED(HttpStatus.OK,"방이 성공적으로 생성되었습니다."),
+    ROOM_FETCHED(HttpStatus.OK,"기존 채팅방을 불러왔습니다."),
     DATA_FETCHED(HttpStatus.OK, "데이터 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣ Issue Number

#100 

## 📝 작업 설명

웹 소켓에서 사용자 정보가 필요한 부분에 세션을 받아와서 사용할 수 있도록 수정했습니다.
1. 메시지 전송
 - 기존에 전송 값에 senderId를 포함해서 보냈는데, 이제 로그인 후 사용자 정보를 가져오기 때문에 메시지 내용만 전송하면 됩니다.
2. 메시지 읽음 처리
 - 메시지 읽음 처리가 REST API, WebSocket 컨트롤러 두 부분에서 모두 사용되는데 기존에 REST API의 서비스 단에 메서드를 구현 해 놓아서 HttpServletRequest 타입으로 세션을 받아 처리하는 방식이었습니다.
 - 하지만 WebSocket의 경우 SimpMessageHeaderAccessor 타입으로 세션을 처리하기 때문에, 일단 각 컨트롤러에서 User 객체를 얻는 로직을 구현하고 User를 서비스로 직접 넘기도록 임시로 구현했습니다.
 - HttpServletRequest 방식에서 현재 다른 방식으로 변경 중인 것으로 알고 있어서 추후에 이 부분은 다시 수정하겠습니다.
3. 채팅방 생성 성공 응답 코드 분리 
 - 채팅방 생성 API 호출 시 기존의 채팅방을 조회하거나, 새로운 채팅방을 생성합니다.
 - 두 경우 모두 "새로운 채팅방을 생성합니다." 로 응답하기 때문에 각 응답코드를 다르게 반환하도록 변경했습니다.

## 📸스크린샷 (선택)   

## 💬 리뷰 요구사항

리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요.   
논의해야할 부분이 있다면 적어주세요.   
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
